### PR TITLE
Training option to specify validation path

### DIFF
--- a/clair3/Train.py
+++ b/clair3/Train.py
@@ -62,27 +62,18 @@ class FocalLoss(tf.keras.losses.Loss):
         return reduce_fl
 
 
-def get_chunk_list(chunk_offset, train_data_size, chunk_size):
+def get_chunk_list(chunk_offset, train_chunk_num):
     """
     get chunk list for training and validation data. we will randomly split training and validation dataset,
     all training data is directly acquired from various tensor bin files.
 
     """
     all_shuffle_chunk_list = []
-    total_size = 0
-    offset_idx = 0
     for bin_idx, chunk_num in enumerate(chunk_offset):
         all_shuffle_chunk_list += [(bin_idx, chunk_idx) for chunk_idx in range(chunk_num)]
     np.random.seed(0)
     np.random.shuffle(all_shuffle_chunk_list)  # keep the same random validate dataset
-    for bin_idx, chunk_num in enumerate(chunk_offset):
-        if chunk_num * chunk_size + total_size >= train_data_size:
-            chunk_num = (train_data_size - total_size) // chunk_size
-            offset_idx += chunk_num
-            return np.array(all_shuffle_chunk_list[:offset_idx]), np.array(all_shuffle_chunk_list[offset_idx + 1:])
-        else:
-            total_size += chunk_num * chunk_size
-            offset_idx += chunk_num
+    return np.array(all_shuffle_chunk_list[:train_chunk_num]), np.array(all_shuffle_chunk_list[train_chunk_num:])
 
 
 def exist_file_prefix(exclude_training_samples, f):
@@ -111,6 +102,7 @@ def train_model(args):
     label_size, label_shape = param.label_size, param.label_shape
     label_shape_cum = list(accumulate(label_shape))
     batch_size, chunk_size = param.trainBatchSize, param.chunk_size
+    chunks_per_batch = batch_size // chunk_size
     random.seed(param.RANDOM_SEED)
     np.random.seed(param.RANDOM_SEED)
     learning_rate = args.learning_rate if args.learning_rate else param.initialLearningRate
@@ -120,32 +112,36 @@ def train_model(args):
     tf.TensorShape([None] + tensor_shape), tuple(tf.TensorShape([None, label_shape[task]]) for task in range(task_num)))
     TensorDtype = (tf.int32, tuple(tf.float32 for _ in range(task_num)))
 
+    def populate_dataset_table(file_list, file_path):
+        chunk_offset = np.zeros(len(file_list), dtype=int)
+        table_dataset_list = []
+        for bin_idx, bin_file in enumerate(file_list):
+            table_dataset = tables.open_file(os.path.join(file_path, bin_file), 'r')
+            table_dataset_list.append(table_dataset)
+            chunk_num = (len(table_dataset.root.label) - chunk_size) // chunk_size
+            chunk_offset[bin_idx] = chunk_num
+        return table_dataset_list, chunk_offset
+
     bin_list = os.listdir(args.bin_fn)
     # default we exclude sample hg003 and all chr20 for training
     bin_list = [f for f in bin_list if '_20_' not in f and not exist_file_prefix(exclude_training_samples, f)]
     logging.info("[INFO] total {} training bin files: {}".format(len(bin_list), ','.join(bin_list)))
-    total_data_size = 0
-    table_dataset_list = []
-    validate_table_dataset_list = []
-    chunk_offset = np.zeros(len(bin_list), dtype=int)
 
     effective_label_num = None
-    for bin_idx, bin_file in enumerate(bin_list):
-        table_dataset = tables.open_file(os.path.join(args.bin_fn, bin_file), 'r')
-        validate_table_dataset = tables.open_file(os.path.join(args.bin_fn, bin_file), 'r')
-        table_dataset_list.append(table_dataset)
-        validate_table_dataset_list.append(validate_table_dataset)
-        chunk_num = (len(table_dataset.root.label) - batch_size) // chunk_size
-        data_size = int(chunk_num * chunk_size)
-        chunk_offset[bin_idx] = chunk_num
-        total_data_size += data_size
 
-    train_data_size = total_data_size * param.trainingDatasetPercentage
-    validate_data_size = int((total_data_size - train_data_size) // chunk_size) * chunk_size
-    train_data_size = int(train_data_size // chunk_size) * chunk_size
-    train_shuffle_chunk_list, validate_shuffle_chunk_list = get_chunk_list(chunk_offset, train_data_size, chunk_size)
+    table_dataset_list, chunk_offset = populate_dataset_table(bin_list, args.bin_fn)
 
-    def DataGenerator(x, data_size, shuffle_chunk_list, train_flag=True):
+    total_chunks = int(sum(chunk_offset))
+    if add_validation_dataset:
+        total_batches = total_chunks // chunks_per_batch
+        validate_chunk_num = int(max(1., np.floor(total_batches * (1 - param.trainingDatasetPercentage))) * chunks_per_batch)
+        train_chunk_num = int(total_chunks - validate_chunk_num)
+    else:
+        train_chunk_num = total_chunks
+    train_shuffle_chunk_list, validate_shuffle_chunk_list = get_chunk_list(chunk_offset, train_chunk_num)
+
+
+    def DataGenerator(x, shuffle_chunk_list, train_flag=True):
 
         """
         data generator for pileup or full alignment data processing, pytables with blosc:lz4hc are used for extreme fast
@@ -153,18 +149,16 @@ def train_model(args):
 
         """
 
-        chunk_iters = batch_size // chunk_size
-        batch_num = data_size // batch_size
+        batch_num = len(shuffle_chunk_list) // chunks_per_batch
         position_matrix = np.empty([batch_size] + tensor_shape, np.int32)
         label = np.empty((batch_size, param.label_size), np.float32)
 
-        random_start_position = np.random.randint(0, batch_size) if train_flag else 0
+        random_start_position = np.random.randint(0, chunk_size) if train_flag else 0
         if train_flag:
             np.random.shuffle(shuffle_chunk_list)
         for batch_idx in range(batch_num):
-            for chunk_idx in range(chunk_iters):
-                offset_chunk_id = shuffle_chunk_list[batch_idx * chunk_iters + chunk_idx]
-                bin_id, chunk_id = offset_chunk_id
+            for chunk_idx in range(chunks_per_batch):
+                bin_id, chunk_id = shuffle_chunk_list[batch_idx * chunks_per_batch + chunk_idx]
                 position_matrix[chunk_idx * chunk_size:(chunk_idx + 1) * chunk_size] = x[bin_id].root.position_matrix[
                         random_start_position + chunk_id * chunk_size:random_start_position + (chunk_id + 1) * chunk_size]
                 label[chunk_idx * chunk_size:(chunk_idx + 1) * chunk_size] = x[bin_id].root.label[
@@ -185,13 +179,13 @@ def train_model(args):
 
 
     train_dataset = tf.data.Dataset.from_generator(
-        lambda: DataGenerator(table_dataset_list, train_data_size, train_shuffle_chunk_list, True), TensorDtype,
+        lambda: DataGenerator(table_dataset_list, train_shuffle_chunk_list, True), TensorDtype,
         TensorShape).prefetch(buffer_size=tf.data.experimental.AUTOTUNE)
     validate_dataset = tf.data.Dataset.from_generator(
-        lambda: DataGenerator(validate_table_dataset_list, validate_data_size, validate_shuffle_chunk_list, False), TensorDtype,
+        lambda: DataGenerator(table_dataset_list, validate_shuffle_chunk_list, False), TensorDtype,
         TensorShape).prefetch(buffer_size=tf.data.experimental.AUTOTUNE)
 
-    total_steps = max_epoch * train_data_size // batch_size
+    total_steps = max_epoch * (train_chunk_num // chunks_per_batch)
 
     #RectifiedAdam with warmup start
     optimizer = tfa.optimizers.Lookahead(tfa.optimizers.RectifiedAdam(
@@ -218,7 +212,7 @@ def train_model(args):
     output = model(np.array(table_dataset_list[0].root.position_matrix[:20]))
     logging.info(model.summary(print_fn=logging.info))
 
-    logging.info("[INFO] The size of dataset: {}".format(total_data_size))
+    logging.info("[INFO] The size of dataset: {}".format(total_chunks * chunk_size))
     logging.info("[INFO] The training batch size: {}".format(batch_size))
     logging.info("[INFO] The training learning_rate: {}".format(learning_rate))
     logging.info("[INFO] Total training steps: {}".format(total_steps))
@@ -237,9 +231,6 @@ def train_model(args):
                               shuffle=False)
 
     for table_dataset in table_dataset_list:
-        table_dataset.close()
-
-    for table_dataset in validate_table_dataset_list:
         table_dataset.close()
 
     # show the parameter set with the smallest validation loss

--- a/docs/full_alignment_training.md
+++ b/docs/full_alignment_training.md
@@ -356,7 +356,7 @@ ${PYTHON3} ${CLAIR3} Train \
     --bin_fn ${BINS_FOLDER_PATH} \
     --ochk_prefix ${MODEL_FOLDER_PATH}/full_alignment \
     --add_indel_length True \
-    --validation_dataset \
+    --random_validation \
     --platform ${PLATFORM}
     
 ```
@@ -364,7 +364,7 @@ ${PYTHON3} ${CLAIR3} Train \
 **Options**
 
  - `--add_indel_length` :  enable or disable the two indel-length tasks. In the pre-trained models, the two tasks are enabled in full-alignment calling.
- - `--validation_dataset`: randomly holdout 10% from all candidate sites as validation data, the best-performing epoch on the validation data are selected as our pre-trained models.
+ - `--random_validation`: randomly holdout 10% from all candidate sites as validation data, the best-performing epoch on the validation data are selected as our pre-trained models.
 
 #### 2. full-alignment model fine-tune using pre-trained model (optional)
 
@@ -380,7 +380,7 @@ ${PYTHON3} ${CLAIR3} Train \
     --bin_fn ${BINS_FOLDER_PATH} \
     --ochk_prefix ${MODEL_FOLDER_PATH}/full_alignment \
     --add_indel_length True \
-    --validation_dataset \
+    --random_validation \
     --platform ${PLATFORM} \
     --learning_rate 0.0001 \
     --chkpnt_fn "[YOUR_PRETRAINED_MODEL]"  ## use pre-trained full-alignment model here

--- a/docs/pileup_training.md
+++ b/docs/pileup_training.md
@@ -301,7 +301,7 @@ ${PYTHON3} ${CLAIR3} Train \
     --ochk_prefix ${MODEL_FOLDER_PATH}/pileup \
     --pileup \
     --add_indel_length False \
-    --validation_dataset \
+    --random_validation \
     --platform ${PLATFORM}
 
 ```
@@ -310,7 +310,7 @@ ${PYTHON3} ${CLAIR3} Train \
 
  - `--pileup` : enable pileup model training mode. (enable full-alignment mode if the option is not set).
  - `--add_indel_length` :  enable or disable the two indel-length tasks. In the pre-trained models, the two tasks are disabled in pileup calling.
- - `--validation_dataset`: randomly holdout 10% from all candidate sites as validation data, the best-performing epoch on the validation data are selected as our pre-trained models.
+ - `--random_validation`: randomly holdout 10% from all candidate sites as validation data, the best-performing epoch on the validation data are selected as our pre-trained models.
 
 #### 2. Pileup model fine-tune using pre-trained model (option 2)
 
@@ -327,7 +327,7 @@ ${PYTHON3} ${CLAIR3} Train \
     --bin_fn ${BINS_FOLDER_PATH} \
     --ochk_prefix ${MODEL_FOLDER_PATH}/pileup \
     --add_indel_length False \
-    --validation_dataset \
+    --random_validation \
     --platform ${PLATFORM} \
     --learning_rate 0.0001 \
     --chkpnt_fn "[YOUR_PRETRAINED_MODEL]"  ## use pre-trained pileup model here


### PR DESCRIPTION
- Adds an option `--validation_fn` to specify a path to binary files to be used for validation during training, as an alternative to a random validation sample.
- Renames existing `--validation_dataset` to `--random_validation` to make the distinction from `--validation_fn` clearer.
- Also changes the range of `random_start_position` from `batch_size` to `chunk_size`, slightly increasing the fraction of data included in training since only the last `chunk_size`, rather than the last `batch_size`, samples from each input file need to be excluded from the chunk list (there is a separate issue with `random_start_position` leading to an unclean training/validation data split, for which I will post an issue ticket)