### PR TITLE
Fix bug described in #186 causing incorrect reading of AF from the VCF

### DIFF
--- a/postprocess/SwitchZygosityBasedOnSVCalls.py
+++ b/postprocess/SwitchZygosityBasedOnSVCalls.py
@@ -158,7 +158,7 @@ class VcfReader(object):
                 if sum([1 if filter == FILTER else 0 for filter in filter_list]) == 0:
                     continue
 
-            reference, alternate, last_column = columns[3], columns[4], columns[-1]
+            reference, alternate, next_to_last_column, last_column = columns[3], columns[4], columns[-2], columns[-1]
 
             if self.sv_input:
                 if self.sv_alt_tag is not None:
@@ -194,7 +194,8 @@ class VcfReader(object):
                 alternate = ''.join([alt_base for alt_base in alternate if alt_base != '*'])
 
             try:
-                af = float(last_column.split(':')[3])
+                af_idx = next_to_last_column.split(':').index('AF')
+                af = float(last_column.split(':')[af_idx])
             except:
                 af = None
 


### PR DESCRIPTION
Hi, I came across the same issue describe in #186. The issue that the `SwitchZygosityBasedOnSVCalls` script assumes the AF field is the third in the genotype column, which might not be the case. To prevent the issue, I've extracted also the `FORMAT` column, split it and used the `AF` index as input for setting the `v.af`. This will help when working with inconsistent formatting, or future-proof it in case the FORMAT field changes order of the individual values.

Cheers
Andrea Talenti