### PR TITLE
Avoid potentially large stack allocation, clean up int usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ CFLAGS	= -fpic -std=c99 -O3 -I ${PREFIX}/include -L ${PREFIX}/lib
 CPPFLAGS	=	-std=c++11 -Wall -O3 -I ${PREFIX}/include -L ${PREFIX}/lib -Wl,-rpath=${PREFIX}/lib
 LP_CPPFLAGS	 =	-std=c++11 -Wall -g -O3 -I ${PREFIX}/include -L ${PREFIX}/lib -Wl,-rpath=${PREFIX}/lib
 
+
+
 samtools-$(SAMVER)/Makefile:
 		curl -L -o samtools-${SAMVER}.tar.bz2 https://github.com/samtools/samtools/releases/download/${SAMVER}/samtools-${SAMVER}.tar.bz2; \
 		tar -xjf samtools-${SAMVER}.tar.bz2; \
@@ -26,7 +28,6 @@ libhts.a: samtools-$(SAMVER)/Makefile
 	@echo "\x1b[1;33mMaking $(@F)\x1b[0m"
 	cd samtools-${SAMVER}/htslib-${SAMVER}; CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure; make CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
 	cp samtools-${SAMVER}/htslib-${SAMVER}/$@ $@
-
 
 longphase-$(LPVER)/Makefile:
 	curl -L -o longphase-${LPVER}.tar.gz https://github.com/twolinin/longphase/archive/refs/tags/v${LPVER}.tar.gz; \
@@ -39,7 +40,7 @@ longphase: longphase-$(LPVER)/Makefile
 	cp longphase-${LPVER}/$@ $@
 
 
-libclair3.so: samtools-${SAMVER}/htslib-${SAMVER}
+libclair3.so: samtools-${SAMVER}/htslib-${SAMVER} libhts.a
 	${PYTHON} build.py
 
 

--- a/src/clair3_full_alignment.h
+++ b/src/clair3_full_alignment.h
@@ -14,7 +14,7 @@ static const int8_t HAP_TYPE[3] = {60, 30, 90};
 #define normalize_hap(x) (HAP_TYPE[x])
 
 static const size_t overhang = 10;
-static const char *RN = "\0";
+//static const char *RN = "\0"; // unused
 static const size_t min_haplotag_mq = 20;
 static const size_t expand_reference_region = 2000000;
 static const size_t flanking_base_num = 16;

--- a/src/clair3_pileup.c
+++ b/src/clair3_pileup.c
@@ -212,8 +212,8 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
         size_t ins_count = 0;
 
         bool pass_af = false;
-        bool pass_snp_af = false;
-        bool pass_indel_af = false;
+        //bool pass_snp_af = false;  // ununsed
+        //bool pass_indel_af = false;  // unused
 
         const char *c_name = data->hdr->target_name[tid];
         if (strcmp(c_name, chr) != 0) continue;
@@ -222,7 +222,7 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
         n_cols++;
 
 
-        if (pre_pos + 1 != pos || pre_pos == 0)
+        if (pre_pos + 1 != (size_t)pos || pre_pos == 0)
             contiguous_flanking_num = 0;
         else
             contiguous_flanking_num++;
@@ -355,7 +355,7 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
         for (size_t i = 0; i < 4; i++) {
             forward_sum += pileup->matrix[major_col + i];
             reverse_sum += pileup->matrix[major_col + i + reverse_pos_start];
-            if (i == ref_offset_forward) {
+            if (i == (size_t)ref_offset_forward) {
                 ref_count = pileup->matrix[major_col + i] + pileup->matrix[major_col + i + reverse_pos_start];
             } else {
                 size_t current_count = pileup->matrix[major_col + i] + pileup->matrix[major_col + i + reverse_pos_start];
@@ -397,15 +397,15 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
             size_t max_alt_length = 64;
             char *alt_info_str = xalloc(max_alt_length, sizeof(char), "alt_info_str");
 
-            sprintf(alt_info_str, "%i-%i-%c-", pos+1, depth, ref_base);
+            sprintf(alt_info_str, "%i-%zu-%c-", pos+1, depth, ref_base);
             //snp
             for (size_t i = 0; i < 4; i++) {
                 forward_sum += pileup->matrix[major_col + i];
                 reverse_sum += pileup->matrix[major_col + i + reverse_pos_start];
                 size_t alt_sum = pileup->matrix[major_col + i] + pileup->matrix[major_col + i + reverse_pos_start];
 
-                if (alt_sum > 0 && i != ref_offset_forward)
-                    sprintf(alt_info_str + strlen(alt_info_str), "X%c %i ", plp_bases_clair3[i], alt_sum);
+                if (alt_sum > 0 && i != (size_t)ref_offset_forward)
+                    sprintf(alt_info_str + strlen(alt_info_str), "X%c %zu ", plp_bases_clair3[i], alt_sum);
             }
             //del
             for (size_t i = 0; i < del_buf_size; i++) {
@@ -418,7 +418,7 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
                             max_alt_length = max_alt_length << 1;
                          alt_info_str = xrealloc(alt_info_str, max_alt_length*sizeof(char), "alt_info_str");
                     }
-                    sprintf(alt_info_str + strlen(alt_info_str), "D%.*s %i ", i+1,ref_seq+offset+1, d);
+                    sprintf(alt_info_str + strlen(alt_info_str), "D%.*s %zu ", (int)i+1, ref_seq+offset+1, d);
                 }
 
             }
@@ -434,7 +434,7 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
                                  max_alt_length = max_alt_length << 1;
                              alt_info_str = xrealloc(alt_info_str, max_alt_length *sizeof(char), "alt_info_str");
                         }
-                        sprintf(alt_info_str + strlen(alt_info_str), "I%c%s %i ", ref_base, key, val);
+                        sprintf(alt_info_str + strlen(alt_info_str), "I%c%s %zu ", ref_base, key, val);
                     }
                 }
             }

--- a/src/medaka_common.c
+++ b/src/medaka_common.c
@@ -62,9 +62,10 @@ char *substring(char *string, int position, int length) {
    char *ptr;
    size_t i;
 
+   if(length < 0) return NULL;
    ptr = malloc(length + 1);
 
-   for (i = 0 ; i < length ; i++) {
+   for (i = 0 ; i < (size_t) length ; i++) {
       *(ptr + i) = *(string + position);
       string++;
    }

--- a/src/medaka_khcounter.c
+++ b/src/medaka_khcounter.c
@@ -93,8 +93,8 @@ void kh_counter_print(khash_t(KH_COUNTER) *hash) {
             printf("%s -> %i\n", key, val);
         }
     }
-    kh_counter_stats_t stats = kh_counter_stats(hash);
-//    printf("max: %i, sum: %i\n", stats.max, stats.sum);
+    //kh_counter_stats_t stats = kh_counter_stats(hash);
+    //printf("max: %i, sum: %i\n", stats.max, stats.sum);
 }
 
 


### PR DESCRIPTION
I'm starting to investigate various memory errors we have seen with clair3 code. This commit is a small one have getting acquianted with the bits full alignment feature code (the pileup one seems very familiar 🤔 🤣 ).

* Avoids a stack allocation (fixes #265)
* Cleans up integer use (I didn't think very long about all the casts, they look safe by inspection)

My compiler is a bit happier after these changes.