### PR TITLE
Fa test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ longphase: longphase-$(LPVER)/Makefile
 libclair3.so: samtools-${SAMVER}/htslib-${SAMVER} libhts.a
 	${PYTHON} build.py
 
+src/%.o: src/%.c
+	$(GCC) -Isrc -Isamtools-${SAMVER}/htslib-${SAMVER} -c -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+		$(CFLAGS) $^ -o $@
+
+fa_test: src/fa_test.o src/levenshtein.o src/medaka_bamiter.o src/medaka_common.o src/medaka_khcounter.o src/clair3_pileup.o src/clair3_full_alignment.o
+	gcc -Isrc -L ./ -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+		$(CFLAGS) $^ \
+		-lhts -llzma -lcurl -lcrypto -lz -lm -lbz2 -o $@
 
 .PHONY: clean_htslib
 clean_htslib:

--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,14 @@ libclair3.so: samtools-${SAMVER}/htslib-${SAMVER} libhts.a
 	${PYTHON} build.py
 
 src/%.o: src/%.c
-	$(GCC) -Isrc -Isamtools-${SAMVER}/htslib-${SAMVER} -c -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+	$(GCC) -g -Isrc -Isamtools-${SAMVER}/htslib-${SAMVER} -c -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
 		$(CFLAGS) $^ -o $@
 
-fa_test: src/fa_test.o src/levenshtein.o src/medaka_bamiter.o src/medaka_common.o src/medaka_khcounter.o src/clair3_pileup.o src/clair3_full_alignment.o
-	gcc -Isrc -L ./ -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+fa_test: src/fa_test.o src/levenshtein.o src/medaka_bamiter.o src/medaka_common.o src/medaka_khcounter.o src/clair3_pileup.o src/clair3_full_alignment.o src/csv.o
+	gcc -g -Isrc -L ./ -pthread -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
 		$(CFLAGS) $^ \
 		-lhts -llzma -lcurl -lcrypto -lz -lm -lbz2 -o $@
+
 
 .PHONY: clean_htslib
 clean_htslib:

--- a/src/clair3_full_alignment.c
+++ b/src/clair3_full_alignment.c
@@ -152,7 +152,7 @@ char *get_ref_seq(char *ref_seq, size_t start, size_t end)
 {
 
     size_t seq_size = end - start;
-    char *sub_seq = malloc((seq_size + 1));
+    char *sub_seq = calloc(seq_size + 1, sizeof(char));
     strncpy(sub_seq, ref_seq + start, seq_size);
     sub_seq[seq_size] = '\0';
     return sub_seq;
@@ -178,7 +178,7 @@ char *get_query_seq(uint8_t *seqi, size_t start, size_t end)
 {
 
     size_t seq_size = end - start;
-    char *sub_seq = malloc((seq_size + 1));
+    char *sub_seq = calloc(seq_size + 1, sizeof(char));
     for (size_t i = 0; i < seq_size; i++)
     {
         sub_seq[i] = seq_nt16_str[bam_seqi(seqi, start + i)];
@@ -222,11 +222,18 @@ int realign_read(Variant *variant, Read *read, size_t i, size_t consumed, size_t
     cigar_prefix_length(cigartuples, overhang, &left_ref_bases, &left_query_bases, 0, left_cigar_size, left_consumed, true);
     cigar_prefix_length(cigartuples, overhang + 1, &right_ref_bases, &right_query_bases, right_cigar_size, n_cigar, right_consumed, false);
 
-    char *query = get_query_seq(seqi, query_pos - left_query_bases, query_pos + right_query_bases);
-    char *ref = get_ref_seq(reference, variant->position - left_ref_bases - ref_start, variant->position + right_ref_bases - ref_start);
+    size_t qst = query_pos - left_query_bases;
+    size_t qen = query_pos + right_query_bases;
+    size_t rst = variant->position - left_ref_bases - ref_start;
+    size_t ren = variant->position + right_ref_bases - ref_start;
+    if (qen == qst) return 0;  // fast return
+    char *query = get_query_seq(seqi, qst, qen);
+    char *ref = get_ref_seq(reference, rst, ren);
 
-    size_t alt_length = left_ref_bases + right_ref_bases + 1;
-    char *alt = malloc(alt_length);
+    // I'm not convinced an extra char here is correct, but it
+    // stops valgrind complaining
+    size_t alt_length = left_ref_bases + right_ref_bases;
+    char *alt = calloc(alt_length + 2, sizeof(char));
     strcpy(alt, ref);
     alt[left_ref_bases] = variant->alt_base;
 
@@ -234,12 +241,10 @@ int realign_read(Variant *variant, Read *read, size_t i, size_t consumed, size_t
     size_t distance_alt = levenshtein(query, alt);
 
     int allele = 0;
-    if (distance_ref < distance_alt)
-    {
+    if (distance_ref < distance_alt) {
         allele = 1;
     }
-    else if (distance_ref > distance_alt)
-    {
+    else if (distance_ref > distance_alt) {
         allele = 2;
     }
 
@@ -513,8 +518,9 @@ size_t min_mq, size_t min_bq, size_t matrix_depth, size_t max_indel_length)
             .pos_info = NULL,
             .haplotype = HAP_UNPHASED};
 
-        while (variant_current_pos < variant_num && variants[variant_current_pos]->position < pos)
+        while (variant_current_pos < variant_num && variants[variant_current_pos]->position < pos) {
             variant_current_pos++;
+        }
         variants_info.variant_current_pos = variant_current_pos;
 
         while (candidate_current_index < flanking_candidates_num && flanking_candidates[candidate_current_index] < (size_t)pos)
@@ -910,8 +916,14 @@ size_t min_mq, size_t min_bq, size_t matrix_depth, size_t max_indel_length)
     kh_int_counter_destroy(candidates_p);
     kh_int_counter_destroy(flanking_candidates_p);
     kv_destroy(read_array);
+
     bam_destroy1(alignment);
     hts_itr_destroy(iter);
+    sam_hdr_destroy(header);
+    hts_idx_destroy(idx);
+    hts_close(hts_file);
+
+    free(ref_seq);
     fai_destroy(fai);
 
     return data;

--- a/src/clair3_full_alignment.c
+++ b/src/clair3_full_alignment.c
@@ -230,11 +230,12 @@ int realign_read(Variant *variant, Read *read, size_t i, size_t consumed, size_t
     char *query = get_query_seq(seqi, qst, qen);
     char *ref = get_ref_seq(reference, rst, ren);
 
-    // I'm not convinced an extra char here is correct, but it
-    // stops valgrind complaining
-    size_t alt_length = left_ref_bases + right_ref_bases;
+    // right_ref_bases can be zero, alt[left_ref_bases] would then be
+    // accessing the last char in the string, either we need another
+    // character or it should be alt[left_ref_bases - 1]? :/
+    size_t alt_length = left_ref_bases + right_ref_bases;  // equivalently ren - rst
     char *alt = calloc(alt_length + 2, sizeof(char));
-    strcpy(alt, ref);
+    strncpy(alt, ref, ren - rst);
     alt[left_ref_bases] = variant->alt_base;
 
     size_t distance_ref = levenshtein(query, ref);

--- a/src/clair3_pileup.c
+++ b/src/clair3_pileup.c
@@ -470,8 +470,3 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
 
     return pileup;
 }
-
-int main()
-{
-    return 0;
-}

--- a/src/csv.c
+++ b/src/csv.c
@@ -1,0 +1,543 @@
+/* Copyright (c) 2019 Jan Doczy
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "csv.h"
+
+/* Windows specific */
+#ifdef _WIN32
+#include <Windows.h>
+typedef unsigned long long file_off_t;
+#else
+#include <sys/types.h>
+typedef off_t file_off_t;
+#endif
+
+/* max allowed buffer */
+#define BUFFER_WIDTH_APROX (40 * 1024 * 1024)
+
+#if defined (__aarch64__) || defined (__amd64__) || defined (_M_AMD64)
+/* unpack csv newline search */
+#define CSV_UNPACK_64_SEARCH
+#endif
+
+/* private csv handle:
+ * @mem: pointer to memory
+ * @pos: position in buffer
+ * @size: size of memory chunk
+ * @context: context used when processing cols
+ * @blockSize: size of mapped block
+ * @fileSize: size of opened file
+ * @mapSize: ...
+ * @auxbuf: auxiliary buffer
+ * @auxbufSize: size of aux buffer
+ * @auxbufPos: position of aux buffer reader
+ * @quotes: number of pending quotes parsed
+ * @fh: file handle - descriptor
+ * @delim: delimeter - ','
+ * @quote: quote '"'
+ * @escape: escape char
+ */
+struct CsvHandle_
+{
+    void* mem;
+    size_t pos;
+    size_t size;
+    char* context;
+    size_t blockSize;
+    file_off_t fileSize;
+    file_off_t mapSize;
+    size_t auxbufSize;
+    size_t auxbufPos;
+    size_t quotes;
+    void* auxbuf;
+    
+#if defined ( __unix__ )
+    int fh;
+#elif defined ( _WIN32 )
+    HANDLE fh;
+    HANDLE fm;
+#else
+    #error Wrong platform definition
+#endif
+
+    char delim;
+    char quote;
+    char escape;
+};
+
+CsvHandle CsvOpen(const char* filename)
+{
+    /* defaults */
+    return CsvOpen2(filename, ',', '"', '\\');
+}
+
+/* trivial macro used to get page-aligned buffer size */
+#define GET_PAGE_ALIGNED( orig, page ) \
+    (((orig) + ((page) - 1)) & ~((page) - 1))
+
+/* thin platform dependent layer so we can use file mapping
+ * with winapi and oses following posix specs.
+ */
+#ifdef __unix__
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+CsvHandle CsvOpen2(const char* filename,
+                   char delim,
+                   char quote,
+                   char escape)
+{
+    /* alloc zero-initialized mem */
+    long pageSize;
+    struct stat fs;
+
+    CsvHandle handle = calloc(1, sizeof(struct CsvHandle_));
+    if (!handle)
+        goto fail;
+
+    /* set chars */
+    handle->delim = delim;
+    handle->quote = quote;
+    handle->escape = escape;
+
+    /* page size */
+    pageSize = sysconf(_SC_PAGESIZE);
+    if (pageSize < 0)
+        goto fail;
+
+    /* align to system page size */
+    handle->blockSize = GET_PAGE_ALIGNED(BUFFER_WIDTH_APROX, pageSize);
+    
+    /* open new fd */
+    handle->fh = open(filename, O_RDONLY);
+    if (handle->fh < 0)
+        goto fail;
+
+    /* get real file size */
+    if (fstat(handle->fh, &fs))
+    {
+       close(handle->fh);
+       goto fail;
+    }
+    
+    handle->fileSize = fs.st_size;
+    return handle;
+    
+  fail:
+    free(handle);
+    return NULL;
+}
+
+static void* MapMem(CsvHandle handle)
+{
+    handle->mem = mmap(0, handle->blockSize,
+                       PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE,
+                       handle->fh, handle->mapSize);
+    return handle->mem;
+}
+
+static void UnmapMem(CsvHandle handle)
+{
+    if (handle->mem)
+        munmap(handle->mem, handle->blockSize);
+}
+
+void CsvClose(CsvHandle handle)
+{
+    if (!handle)
+        return;
+
+    UnmapMem(handle);
+
+    close(handle->fh);
+    free(handle->auxbuf);
+    free(handle);
+}
+
+#else
+
+/* extra Windows specific implementations
+ */
+CsvHandle CsvOpen2(const char* filename,
+                   char delim,
+                   char quote,
+                   char escape)
+{
+    LARGE_INTEGER fsize;
+    SYSTEM_INFO info;
+    size_t pageSize = 0;
+    CsvHandle handle = calloc(1, sizeof(struct CsvHandle_));
+    if (!handle)
+        return NULL;
+
+    handle->delim = delim;
+    handle->quote = quote;
+    handle->escape = escape;
+
+    GetSystemInfo(&info);
+    handle->blockSize = GET_PAGE_ALIGNED(BUFFER_WIDTH_APROX, info.dwPageSize);
+    handle->fh = CreateFile(filename, 
+                            GENERIC_READ, 
+                            FILE_SHARE_READ, 
+                            NULL, 
+                            OPEN_EXISTING, 
+                            FILE_ATTRIBUTE_NORMAL, 
+                            NULL);
+
+    if (handle->fh == INVALID_HANDLE_VALUE)
+        goto fail;
+
+    if (GetFileSizeEx(handle->fh, &fsize) == FALSE)
+        goto fail;
+
+    handle->fileSize = fsize.QuadPart;
+    if (!handle->fileSize)
+        goto fail;
+
+    handle->fm = CreateFileMapping(handle->fh, NULL, PAGE_WRITECOPY, 0, 0, NULL);
+    if (handle->fm == NULL)
+        goto fail;
+
+    return handle;
+
+fail:
+    if (handle->fh != INVALID_HANDLE_VALUE)
+        CloseHandle(handle->fh);
+
+    free(handle);
+    return NULL;
+}
+
+static void* MapMem(CsvHandle handle)
+{
+    size_t size = handle->blockSize;
+    if (handle->mapSize + size > handle->fileSize)
+        size = 0;  /* last chunk, extend to file mapping max */
+
+    handle->mem = MapViewOfFileEx(handle->fm, 
+                                  FILE_MAP_COPY,
+                                  (DWORD)(handle->mapSize >> 32),
+                                  (DWORD)(handle->mapSize & 0xFFFFFFFF),
+                                  size,
+                                  NULL);
+    return handle->mem;
+}
+
+static void UnmapMem(CsvHandle handle)
+{
+    if (handle->mem)
+        UnmapViewOfFileEx(handle->mem, 0);
+}
+
+void CsvClose(CsvHandle handle)
+{
+    if (!handle)
+        return;
+
+    UnmapMem(handle);
+
+    CloseHandle(handle->fm);
+    CloseHandle(handle->fh);
+    free(handle->auxbuf);
+    free(handle);
+}
+
+#endif
+
+static int CsvEnsureMapped(CsvHandle handle)
+{
+    file_off_t newSize;
+    
+    /* do not need to map */
+    if (handle->pos < handle->size)
+        return 0;
+
+    UnmapMem(handle);  
+
+    handle->mem = NULL;
+    if (handle->mapSize >= handle->fileSize)
+        return -EINVAL;
+
+    newSize = handle->mapSize + handle->blockSize;
+    if (MapMem(handle))
+    {
+        handle->pos = 0;
+        handle->mapSize = newSize;
+
+        /* read only up to filesize:
+         * 1. mapped block size is < then filesize: (use blocksize)
+         * 2. mapped block size is > then filesize: (use remaining filesize) */
+        handle->size = handle->blockSize;
+        if (handle->mapSize > handle->fileSize)
+            handle->size = (size_t)(handle->fileSize % handle->blockSize);
+        
+        return 0;
+    }
+    
+    return -ENOMEM;
+}
+
+static char* CsvChunkToAuxBuf(CsvHandle handle, char* p, size_t size)
+{
+    size_t newSize = handle->auxbufPos + size + 1;
+    if (handle->auxbufSize < newSize)
+    {
+        void* mem = realloc(handle->auxbuf, newSize);
+        if (!mem)
+            return NULL;
+
+        handle->auxbuf = mem;
+        handle->auxbufSize = newSize;
+    }
+
+    memcpy((char*)handle->auxbuf + handle->auxbufPos, p, size);
+    handle->auxbufPos += size;
+    
+    *(char*)((char*)handle->auxbuf + handle->auxbufPos) = '\0';
+    return handle->auxbuf;
+}
+
+static void CsvTerminateLine(char* p, size_t size)
+{
+    /* we do support standard POSIX LF sequence
+     * and Windows CR LF sequence.
+     * old non POSIX Mac OS CR is not supported.
+     */
+    char* res = p;
+    if (size >= 2 && p[-1] == '\r')
+        --res;
+
+    *res = 0;
+}
+
+#define CSV_QUOTE_BR(c, n) \
+    do \
+        if (c##n == quote)                              \
+            handle->quotes++;                           \
+        else if (c##n == '\n' && !(handle->quotes & 1)) \
+            return p + n;                               \
+    while (0)
+
+
+static char* CsvSearchLf(char* p, size_t size, CsvHandle handle)
+{
+    /* TODO: this can be greatly optimized by
+     * using modern SIMD instructions, but for now
+     * we only fetch 8Bytes "at once"
+     */
+    char* end = p + size;
+    char quote = handle->quote;
+
+#ifdef CSV_UNPACK_64_SEARCH
+    uint64_t* pd = (uint64_t*)p;
+    uint64_t* pde = pd + (size / sizeof(uint64_t));
+
+    for (; pd < pde; pd++)
+    {
+        /* unpack 64bits to 8x8bits */
+        char c0, c1, c2, c3, c4, c5, c6, c7;
+        p = (char*)pd;
+        c0 = p[0];
+        c1 = p[1];
+        c2 = p[2];
+        c3 = p[3];
+        c4 = p[4];
+        c5 = p[5];
+        c6 = p[6];
+        c7 = p[7];
+
+        CSV_QUOTE_BR(c, 0);
+        CSV_QUOTE_BR(c, 1);
+        CSV_QUOTE_BR(c, 2);
+        CSV_QUOTE_BR(c, 3);
+        CSV_QUOTE_BR(c, 4);
+        CSV_QUOTE_BR(c, 5);
+        CSV_QUOTE_BR(c, 6);
+        CSV_QUOTE_BR(c, 7);
+    }
+    p = (char*)pde;
+#endif
+    
+    for (; p < end; p++)
+    {
+        char c0 = *p;
+        CSV_QUOTE_BR(c, 0);
+    }
+
+    return NULL;
+}
+
+char* CsvReadNextRow(CsvHandle handle)
+{
+    size_t size;
+    char* p = NULL;
+    char* found = NULL;
+
+    do
+    {
+        int err = CsvEnsureMapped(handle);
+        handle->context = NULL;
+        
+        if (err == -EINVAL)
+        {
+            /* if this is n-th iteration
+             * return auxbuf (remaining bytes of the file) */
+            if (p == NULL)
+                break;
+
+            return handle->auxbuf;
+        }
+        else if (err == -ENOMEM)
+        {
+            break;
+        }
+        
+        size = handle->size - handle->pos;
+        if (!size)
+            break;
+
+        /* search this chunk for NL */
+        p = (char*)handle->mem + handle->pos;
+        found = CsvSearchLf(p, size, handle);
+
+        if (found)
+        {
+            /* prepare position for next iteration */
+            size = (size_t)(found - p) + 1;
+            handle->pos += size;
+            handle->quotes = 0;
+            
+            if (handle->auxbufPos)
+            {
+                if (!CsvChunkToAuxBuf(handle, p, size))
+                    break;
+                
+                p = handle->auxbuf;
+                size = handle->auxbufPos;
+            }
+
+            /* reset auxbuf position */
+            handle->auxbufPos = 0;
+
+            /* terminate line */
+            CsvTerminateLine(p + size - 1, size);
+            return p;
+        }
+        else
+        {
+            /* reset on next iteration */
+            handle->pos = handle->size;
+        }
+
+        /* correctly process boundries, storing
+         * remaning bytes in aux buffer */
+        if (!CsvChunkToAuxBuf(handle, p, size))
+            break;
+
+    } while (!found);
+
+    return NULL;
+}
+
+const char* CsvReadNextCol(char* row, CsvHandle handle)
+{
+    /* return properly escaped CSV col
+     * RFC: [https://tools.ietf.org/html/rfc4180]
+     */
+    char* p = handle->context ? handle->context : row;
+    char* d = p; /* destination */
+    char* b = p; /* begin */
+    int quoted = 0; /* idicates quoted string */
+
+    quoted = *p == handle->quote;
+    if (quoted)
+        p++;
+
+    for (; *p; p++, d++)
+    {
+        /* double quote is present if (1) */
+        int dq = 0;
+        
+        /* skip escape */
+        if (*p == handle->escape && p[1])
+            p++;
+
+        /* skip double-quote */
+        if (*p == handle->quote && p[1] == handle->quote)
+        {
+            dq = 1;
+            p++;
+        }
+
+        /* check if we should end */
+        if (quoted && !dq)
+        {
+            if (*p == handle->quote)
+                break;
+        }
+        else if (*p == handle->delim)
+        {
+            break;
+        }
+
+        /* copy if required */
+        if (d != p)
+            *d = *p;
+    }
+    
+    if (!*p)
+    {
+        /* nothing to do */
+        if (p == b)
+            return NULL;
+
+        handle->context = p;
+    }
+    else
+    {
+        /* end reached, skip */
+        *d = '\0';
+        if (quoted)
+        {
+            for (p++; *p; p++)
+                if (*p == handle->delim)
+                    break;
+
+            if (*p)
+                p++;
+            
+            handle->context = p;
+        }
+        else
+        {
+            handle->context = p + 1;
+        }
+    }
+    return b;
+}

--- a/src/csv.h
+++ b/src/csv.h
@@ -1,0 +1,74 @@
+/* Copyright (c) 2019 Jan Doczy
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+/* simple and fast CSV reader:
+ * 1. Open CSV file by calling CsvOpen("filename.csv")
+ * 2. Read CSV row by calling CsvReadNextRow(csv_handle)
+ * 3. Read single CSV line column by calling CsvReadNextCol(returned_row_str, csv_handle)
+ */
+
+#ifndef CSV_H_INCLUDED
+#define CSV_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {  /* C++ name mangling */
+#endif
+
+/* pointer to private handle structure */
+typedef struct CsvHandle_ *CsvHandle;
+
+/**
+ * openes csv file
+ * @filename: pathname of the file
+ * @return: csv handle
+ * @notes: you should call CsvClose() to release resources
+ */
+CsvHandle CsvOpen(const char* filename);
+CsvHandle CsvOpen2(const char* filename,
+                   char delim,
+                   char quote,
+                   char escape);
+
+/**
+ * closes csv handle, releasing all resources
+ * @handle: csv handle
+ */
+void CsvClose(CsvHandle handle);
+
+/**
+ * reads (first / next) line of csv file
+ * @handle: csv handle
+ */
+char* CsvReadNextRow(CsvHandle handle);
+
+/**
+ * get column of file
+ * @row: csv row (you can use CsvReadNextRow() to parse next line)
+ * @context: handle returned by CsvOpen() or CsvOpen2()
+ */
+const char* CsvReadNextCol(char* row, CsvHandle handle);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/src/fa_test.c
+++ b/src/fa_test.c
@@ -1,0 +1,39 @@
+
+#include <stdbool.h>
+#include <time.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "clair3_full_alignment.h"
+
+int main(int argc, char *argv[]) {
+    clock_t begin = clock();
+
+    char *region = argv[1];
+    char *bam = argv[2];
+    char *fasta = argv[3];
+
+    size_t variant_num = 10;
+    Variant **variants = malloc(variant_num * sizeof(Variant));
+    size_t candidate_num = 10;
+    size_t *candidates = malloc(candidate_num * sizeof(size_t));
+    bool need_haplotagging = true;
+    size_t min_mq = 10;
+    size_t minb_bq = 10;
+    size_t matrix_depth = 100;
+    size_t max_indel_length = 10;
+
+
+    fa_data data = calculate_clair3_full_alignment(
+        region, bam, fasta,
+        variants, variant_num,
+        candidates, candidate_num,
+        need_haplotagging,
+        min_mq, min_bq, matrix_depth, max_indel_length);
+    destroy_fa_data(data);
+
+    clock_t end = clock();
+    fprintf(stderr, "Total CPU time: %fs\n", (double)(end - begin) / CLOCKS_PER_SEC);
+    exit(EXIT_SUCCESS);
+}

--- a/src/fa_test.c
+++ b/src/fa_test.c
@@ -1,37 +1,153 @@
-
+#include <assert.h>
 #include <stdbool.h>
 #include <time.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "clair3_full_alignment.h"
+#include "csv.h"
+
+typedef struct Variants {
+    size_t num_variants;
+    Variant** variants;
+} Variants;
+
+
+typedef struct Candidates {
+    size_t num_candidates;
+    size_t* candidates;
+} Candidates;
+
+
+Variants read_variants(char *input) {
+    // reads a file laid out as:
+    // <num_variants>
+    // pos,ref_base,alt_base,genotype,phase_set
+    // ...
+    char* row;
+    char* col;
+    CsvHandle handle = CsvOpen(input);
+    if (handle == NULL) {
+        fprintf(stderr, "Failed to read file\n");
+        CsvClose(handle);
+        return (Variants){0, NULL};
+    }
+
+    // first row is number of subsequent lines
+    row = CsvReadNextRow(handle);
+    size_t num_variants = atoi(row);
+    Variant** variants = malloc(num_variants * sizeof(Variant*));
+
+    int nrows = 0;
+    Variant* var;
+    while (row = CsvReadNextRow(handle)) {
+        var = malloc(sizeof(Variant));
+        var->position = atoi(CsvReadNextCol(row, handle));
+        memcpy(&(var->ref_base), CsvReadNextCol(row, handle), 1);
+        memcpy(&(var->alt_base), CsvReadNextCol(row, handle), 1);
+        var->genotype = atoi(CsvReadNextCol(row, handle));
+        var->phase_set = atoi(CsvReadNextCol(row, handle));
+        variants[nrows] = var;
+        nrows++;
+        if (nrows == num_variants) break;
+    }
+    //fprintf(
+    //    stderr, "%d, %c, %c, %d, %d\n",
+    //    var->position, var->ref_base, var->alt_base, var->genotype, var->phase_set);
+    CsvClose(handle);
+    return (Variants){num_variants, variants};
+}
+
+
+void free_variants(Variants vars) {
+    for (size_t i=0; i<vars.num_variants; ++i) {
+        free(vars.variants[i]);
+    }
+    free(vars.variants);
+}
+
+
+Candidates read_candidates(char* input) {
+    // reads a file laid out as:
+    // <num_candidates>
+    // cand1,cand2,cand3,cand4,...,candN
+    CsvHandle handle = CsvOpen(input);
+    if (handle == NULL) {
+        fprintf(stderr, "Failed to read file\n");
+        CsvClose(handle);
+        return (Candidates){0, NULL};
+    }
+
+    // first row is number of subsequent lines
+    char* row = CsvReadNextRow(handle);
+    size_t num_candidates = atoi(row);
+    size_t* candidates = malloc(num_candidates * sizeof(size_t));
+
+    int ncols = 0;
+    row = CsvReadNextRow(handle);
+    char* col;
+    for (size_t i=0; i<num_candidates; ++i) {
+        candidates[i] = atoi(CsvReadNextCol(row, handle));
+        //fprintf(stderr, "%zu\n", candidates[i]);
+    }
+    CsvClose(handle);
+    return (Candidates){num_candidates, candidates};
+}
+
+
+void free_candidates(Candidates cand) {
+    free(cand.candidates);
+}
+
 
 int main(int argc, char *argv[]) {
+    // input data as dumped from Python
+    //b'chr15:52446617-58814563'
+    //b'chr15:52446617-58814563'
+    //b'hg002_hac.pass.bam'
+    //b'GCA_000001405.15_GRCh38_no_alt_analysis_set.fna'
+    //<cdata 'struct Variant *[]' owning 466496 bytes>
+    //58312
+    //<cdata 'size_t[10000]' owning 80000 bytes>
+    //10000
+    //True
+    //5
+    //0
+    //89
+    //50
     clock_t begin = clock();
 
-    char *region = argv[1];
-    char *bam = argv[2];
-    char *fasta = argv[3];
+    char *region = argv[1];             // "chr15:52446617-58814563";
+    char *bam = argv[2];                // "hg002_hac.pass.bam";
+    char *fasta = argv[3];              // "GCA_000001405.15_GRCh38_no_alt_analysis_set.fna";
+    char* variants_file = argv[4];      // fa_test_variants.txt
+    char* candidates_file = argv[5];    // fa_test_candidates.txt
 
-    size_t variant_num = 10;
-    Variant **variants = malloc(variant_num * sizeof(Variant));
-    size_t candidate_num = 10;
-    size_t *candidates = malloc(candidate_num * sizeof(size_t));
+    Variants variants = read_variants(variants_file);
+    if (variants.num_variants == 0) exit(1);
+    Candidates candidates = read_candidates(candidates_file);
+    if (candidates.num_candidates == 0) exit(1);
+
+    // could take these as input?
     bool need_haplotagging = true;
-    size_t min_mq = 10;
-    size_t minb_bq = 10;
-    size_t matrix_depth = 100;
-    size_t max_indel_length = 10;
-
+    size_t min_mq = 5;
+    size_t minb_bq = 0;
+    size_t matrix_depth = 89;
+    size_t max_indel_length = 50;
 
     fa_data data = calculate_clair3_full_alignment(
         region, bam, fasta,
-        variants, variant_num,
-        candidates, candidate_num,
+        variants.variants, variants.num_variants,
+        candidates.candidates, candidates.num_candidates,
         need_haplotagging,
         min_mq, min_bq, matrix_depth, max_indel_length);
+    // TODO: do something with the data?
     destroy_fa_data(data);
+
+    free_variants(variants);
+    free_candidates(candidates);
 
     clock_t end = clock();
     fprintf(stderr, "Total CPU time: %fs\n", (double)(end - begin) / CLOCKS_PER_SEC);


### PR DESCRIPTION
This PR adds a test program for `calculate_clair3_full_alignment()` for the purposes of debugging any potential memory issues in the function.

Using valgrind with the full Python entrypoint throws lots of noise that can be difficult to filter: its simpler and easier to write a standalone C program to inspect errors. The program does nothing more than read inputs and run the function. I produced sample inputs but dumping the contents of the CFFI pointer to file immediately before the function call in Python. There are some hardcoded values in the C program which I believe are universal.

I quick test shows some invalid reads triggered in the Levenshtein distance code. I haven't yet looked entirely at the cause of all of these: a few I believe are caused when the read has a deletion at the location of the variant. I could certainly reduce the number of invalid reads by adding some guards to the calling of the function.