### PR TITLE
Try to remove the default depth filter in the pileup. Also fix the version

### DIFF
--- a/shared/utils.py
+++ b/shared/utils.py
@@ -248,7 +248,7 @@ def samtools_view_process_from(
         shlex.split("%s view -F 2318 %s %s" % (samtools, bam_file_path, region_str))
     )
 
-def get_header(reference_file_path=None, cmd_fn=None, sample_name="SAMPLE", version='1.0.4', gvcf=False):
+def get_header(reference_file_path=None, cmd_fn=None, sample_name="SAMPLE", version='1.0.7', gvcf=False):
     from textwrap import dedent
 
     if reference_file_path is None or not os.path.exists(reference_file_path):

--- a/src/clair3_pileup.c
+++ b/src/clair3_pileup.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 #include "htslib/sam.h"
 #include "htslib/faidx.h"
 #include "kvec.h"
@@ -167,6 +168,7 @@ plp_data calculate_clair3_pileup(const char *region, const bam_fset* bam_set, co
     data->min_mapQ = min_mq;
 
     bam_mplp_t mplp = bam_mplp_init(1, read_bam, (void **)& data);
+    bam_mplp_set_maxcnt(mplp, INT_MAX);
 
     const bam_pileup1_t **plp = xalloc(1, sizeof(bam_pileup1_t *), "pileup");
     int ret, pos, tid, n_plp;


### PR DESCRIPTION
By default, htslib has a maximum heap size sufficient to store a few thousand reads, resulting in clair3 only using this many reads for calling and reporting. In most use-cases that's not an issue, but in high-coverage amplicon-seq this is undesired, since you're more likely to get wildly incorrect fold-changes and other coverage metrics. I ran into the same issue in a tool I developed using htslib and there the fix turned out to be a simple 1-line change. It'd be good if someone confirmed that this small change fixes that issue :)

I also noticed that clair3 is reporting the wrong version in the headers it produces. I've updated that to 1.0.7, which would presumably be the next release. Ideally this would get updated automatically and though given that this is a mix of shell scripts and python that may be more hassle than it's worth.