### PR TITLE
Optimize pileup calling for high throughput targeted amplicon bed files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN /bin/bash -c "source activate clair3" && \
     conda install -c conda-forge pypy3.6 -y && \
     pypy3 -m ensurepip && \
     pypy3 -m pip install mpmath==1.2.1 && \
-    conda install -c conda-forge tensorflow-cpu==2.8.0 && \
-    conda install -c conda-forge pytables && \
+    conda install -c conda-forge tensorflow-cpu==2.8.0 -y && \
+    conda install -c conda-forge pytables -y && \
     pip install tensorflow-addons && \
     conda install -c anaconda pigz -y && \
     conda install -c anaconda cffi=1.14.4 -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:latest
+FROM continuumio/miniconda3:24.1.2-0
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PATH=/opt/bin:/opt/conda/bin:$PATH
 
@@ -42,14 +42,15 @@ RUN /bin/bash -c "source activate clair3" && \
     rm -rf /root/.cache/pip && \
     echo "source activate clair3" > ~/.bashrc
 
+RUN wget http://www.bio8.cs.hku.hk/clair3/clair3_models/clair3_models.tar.gz -P /opt/models && \
+    tar -zxvf /opt/models/clair3_models.tar.gz -C /opt/models && \
+    rm /opt/models/clair3_models.tar.gz
+
 COPY . .
 
 RUN cd /opt/bin/preprocess/realign && \
     g++ -std=c++14 -O1 -shared -fPIC -o realigner ssw_cpp.cpp ssw.c realigner.cpp && \
     g++ -std=c++11 -shared -fPIC -o debruijn_graph -O3 debruijn_graph.cpp && \
-    wget http://www.bio8.cs.hku.hk/clair3/clair3_models/clair3_models.tar.gz -P /opt/models && \
-    tar -zxvf /opt/models/clair3_models.tar.gz -C /opt/models && \
-    rm /opt/models/clair3_models.tar.gz && \
     cd /opt/bin && \
     make PREFIX=/opt/conda/envs/clair3 PYTHON=/opt/conda/envs/clair3/bin/python && \
     rm -rf /opt/bin/samtools-* /opt/bin/longphase-*

--- a/preprocess/CheckEnvs.py
+++ b/preprocess/CheckEnvs.py
@@ -354,8 +354,11 @@ def CheckEnvs(args):
         return
 
     print('[INFO] Call variant in contigs: {}'.format(' '.join(sorted_contig_list)))
-    print('[INFO] Chunk number for each contig: {}'.format(
-        ' '.join([str(contig_chunk_num[c]) for c in sorted_contig_list])))
+    if default_chunk_num > -1:
+        print('[INFO] Chunk number for each contig: {}'.format(
+            ' '.join([str(contig_chunk_num[c]) for c in sorted_contig_list])))
+    else:
+        print('[INFO] No genome chunking due to chunk_num == -1') 
 
     if default_chunk_num > 0 and max_chunk_length > MAX_CHUNK_LENGTH:
         print(log_warning(

--- a/preprocess/CheckEnvs.py
+++ b/preprocess/CheckEnvs.py
@@ -372,17 +372,20 @@ def CheckEnvs(args):
             '[WARNING] Current maximum contig length {} is much smaller than default chunk size {}, You may set a smaller chunk size by setting --chunk_size=$ for better parallelism.'.format(
                 max(contig_length_list), DEFAULT_CHUNK_SIZE)))
 
-    if is_bed_file_provided:
+    if is_bed_file_provided and default_chunk_num > -1:
         split_extend_bed(bed_fn=bed_fn, output_fn=split_bed_path, contig_set=contig_set)
 
     with open(contig_name_list, 'w') as output_file:
         output_file.write('\n'.join(sorted_contig_list))
 
     with open(chunk_list, 'w') as output_file:
-        for contig_name in sorted_contig_list:
-            chunk_num = contig_chunk_num[contig_name]
-            for chunk_id in range(1, chunk_num + 1):
-                output_file.write(contig_name + ' ' + str(chunk_id) + ' ' + str(chunk_num) + '\n')
+        if default_chunk_num > -1:
+            for contig_name in sorted_contig_list:
+                chunk_num = contig_chunk_num[contig_name]
+                for chunk_id in range(1, chunk_num + 1):
+                    output_file.write(contig_name + ' ' + str(chunk_id) + ' ' + str(chunk_num) + '\n')
+        else:
+            output_file.write("None 0 0\n")
 
 
 def main():
@@ -458,7 +461,7 @@ def main():
     # options for internal process control
     ## The number of chucks to be divided into for parallel processing
     parser.add_argument('--chunk_num', type=int, default=0,
-                        help=SUPPRESS)
+            help="Target number of chunks to divide contigs into for parallel processing. If -1, do not chunk genome")
 
     ## EXPERIMENTAL: Call variants without whatshap phasing in full alignment calling, default: disable.
     parser.add_argument('--no_phasing_for_fa', type=str2bool, default=False,

--- a/scripts/clair3_c_impl.sh
+++ b/scripts/clair3_c_impl.sh
@@ -140,11 +140,22 @@ if [[ ${THREADS_LOW} < 1 ]]; then THREADS_LOW=1; fi
 if [[ ${LONGPHASE_THREADS} < 1 ]]; then LONGPHASE_THREADS=1; fi
 if [ "${PLATFORM}" = "ont" ]; then LP_PLATFORM="ont"; else LP_PLATFORM="pb"; fi
 
+#fix pileup threads based on parallelezation option
+if [ "$CHUNK_NUM" -eq -1 ]; then
+    PARALLEL_THREADS=1
+    INTERNAL_THREADS=$THREADS
+else
+    PARALLEL_THREADS=$THREADS_LOW
+    INTERNAL_THREADS=1
+fi
+
+
+
 cd ${OUTPUT_FOLDER}
 # Pileup calling
 #-----------------------------------------------------------------------------------------------------------------------
 echo "[INFO] 1/7 Call variants using pileup model"
-time ${PARALLEL} --retries ${RETRIES} -C ' ' --joblog ${LOG_PATH}/parallel_1_call_var_bam_pileup.log -j ${THREADS_LOW} \
+time ${PARALLEL} --retries ${RETRIES} -C ' ' --joblog ${LOG_PATH}/parallel_1_call_var_bam_pileup.log -j ${PARALLEL_THREADS} \
 "${PYTHON} ${CLAIR3} CallVariantsFromCffi \
     --chkpnt_fn ${PILEUP_CHECKPOINT_PATH} \
     --bam_fn ${BAM_FILE_PATH} \
@@ -154,6 +165,7 @@ time ${PARALLEL} --retries ${RETRIES} -C ' ' --joblog ${LOG_PATH}/parallel_1_cal
     --extend_bed ${SPLIT_BED_PATH}/{1} \
     --bed_fn ${BED_FILE_PATH} \
     --vcf_fn ${VCF_FILE_PATH} \
+    --threads ${INTERNAL_THREADS} \
     --ctgName {1} \
     --chunk_id {2} \
     --chunk_num {3} \


### PR DESCRIPTION
The outer parallelization of calling variants with the pileup model using GNU parallel is inefficient for targeted amplicon BAM files where large portions of contigs have no supporting reads. In this case, the outer parallelization strategy spins up many processes that use CPU but do no work because they are assigned regions of a contig where there is nothing to do. 

This outer parallelization also causes inefficiency in small, targeted amplicon panels where we tend to run analysis in parallel on many samples, so we want to reduce the number of threads a single sample takes to make room for others. When many of the threads do nothing, this overhead has a higher cost where nothing is happening for a sample for long periods.

To address this I've added new behavior that's invoked by setting chunk_num to -1 (0 already had a special meaning). In this case outer parallelization is disabled and replaced with inner parallelization within tensorflow. All candidates are batched within a single process. If a bed file is provided we achieve further speedups by only looking for candidates in the regions defined by the bed file

Using an in-house targeted amplicon bed file for profiling, I compare the original chunk_num==0 behavior to the new behavior in both the single threaded and threads=4 cases. Note that runtime is the entire analysis, not just the optimized pileup process.

chunk_num | bed provided | threads | wall clock execution time |
------------|---------------|--------|--------------------------|
0                  | no                    | 1           | 9m
-1                 | no                    | 1           | 1m 19s
-1                 | yes                  | 1           | 43s
0                  | no                    | 4           | 2m 47s
-1                 | no                    | 4          | 51s
-1                 | yes                  | 4           | 26s

Note that chunk_num==-1 is not appropriate for whole genome analysis because it uses too much RAM. I have an additional commit that fixes that issue but the the old behavior is still significantly faster than the new behavior when there is broad enough coverage for the GNU parallel threads to be fully utilized

I've made this change only for the Cffi portion of the code because that's what we use. 

fixes #306 