### PR TITLE
Warning message is on same line as next error message

### DIFF
--- a/build.py
+++ b/build.py
@@ -26,7 +26,7 @@ else:
         conda_path = os.environ['CONDA_PREFIX']
         extra_link_args = ['-Wl,-rpath={}/lib'.format(conda_path)]
     except:
-        print("[WARNING] Conda prefix not found, please activate clair3 conda environment first!")
+        print("[WARNING] Conda prefix not found, please activate clair3 conda environment first!\n")
 
 ffibuilder = FFI()
 ffibuilder.set_source("libclair3",


### PR DESCRIPTION
The warning message will appear on the same line as the next error message written to stdout. This causes confusion when trying to debug the root cause of Clair3 not running.