### PR TITLE
Fix multiple definition of free_memory for GCC 10.5.0

### DIFF
--- a/preprocess/realign/debruijn_graph.cpp
+++ b/preprocess/realign/debruijn_graph.cpp
@@ -428,7 +428,7 @@ extern "C" {
 }
 
 extern "C" {
-    void free_memory(struct_str_arr* pointer, int size) {
+    static void free_memory(struct_str_arr* pointer, int size) {
         for (int i=0; i< size; i++) {
             delete [] pointer->consensus[i];
         }

--- a/preprocess/realign/realigner.cpp
+++ b/preprocess/realign/realigner.cpp
@@ -859,7 +859,7 @@ extern "C" {
 }
 
 extern "C" {
-    void free_memory(struct_str_arr* pointer, int size) {
+    static void free_memory(struct_str_arr* pointer, int size) {
         for (int i=0; i< size; i++) {
             delete [] pointer->cigar_string[i];
         }


### PR DESCRIPTION
# Description
This PR addresses a compilation error encountered when building Clair3 on CentOS 7 using GCC 10.5.0. The `free_memory` function was defined in both `realigner.cpp` and `debruijn_graph.cpp` without internal linkage, leading to a "multiple definition" error during the linking stage.

This PR adds the `static` keyword to the definition of `free_memory` in both files to restrict their scope to the translation unit, resolving the conflict.

# Environment
* OS: CentOS Linux 7 (Core)
* Compiler: GCC 10.5.0
* Kernel: Linux 3.10.0-1160.144.1.el7.tuxcare.els3.x86_64

# How to reproduce
Running make in the root directory fails with the following error:
```
/tmp/ccBsAh9y.o: In function `free_memory':
debruijn_graph.cpp:(.text+0x4110): multiple definition of `free_memory'
/tmp/cc4nFvVQ.o:realigner.cpp:(.text+0x2430): first defined here
collect2: error: ld returned 1 exit status
```
# Verification
* The fix has been verified locally on GCC 10.5.0.
* Compilation completes successfully after applying the static keyword:
`g++ -O3 -shared -fPIC -o realigner realigner.cpp ssw.c ssw_cpp.cpp debruijn_graph.cpp -std=c++11`

# NOTE
Note for users with newer compilers: If you are building Clair3 with GCC 10.5.0 or newer on older OS environments (like CentOS 7), you might encounter a "multiple definition" error during **Step 4 — Install Python deps and build C sources** of the **Option 4: Step-by-step (Conda)** installation guide. This PR resolves that conflict, ensuring the build process completes successfully.