### PR TITLE
Error print cleanup and reference fasta index path fix

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import platform
+import sys
 from subprocess import run
 from cffi import FFI
 
@@ -26,7 +27,7 @@ else:
         extra_link_args = ['-Wl,-rpath={}/lib'.format(conda_path)]
         library_dirs.append(os.path.join(conda_path, 'lib'))
     except KeyError:
-        print("[WARNING] Conda prefix not found, please activate clair3 conda environment first!\n")
+        print("[WARNING] Conda prefix not found, please activate clair3 conda environment first!\n", file=sys.stderr)
 
 htslib_static = os.path.join(htslib_dir, 'libhts.a')
 extra_objects = []

--- a/clair3/CallVarBam.py
+++ b/clair3/CallVarBam.py
@@ -79,7 +79,7 @@ def Run(args):
         bam_fn = file_path_from(args.bam_fn)
         if bam_fn is None or bam_fn == "":
             print(log_warning(
-                "[WARNING] Skip full-alignment variant calling for empty full-alignment regions"))
+                "[WARNING] Skip full-alignment variant calling for empty full-alignment regions"), file=sys.stderr)
             return
     ref_fn = file_path_from(args.ref_fn, exit_on_not_found=True)
     bed_fn = file_path_from(args.bed_fn)
@@ -281,26 +281,26 @@ def Run(args):
             c.realign_reads.stdout.close()
             c.realign_reads.wait()
     except KeyboardInterrupt as e:
-        print("KeyboardInterrupt received when waiting at CallVarBam, terminating all scripts.")
+        print("KeyboardInterrupt received when waiting at CallVarBam, terminating all scripts.", file=sys.stderr)
         try:
             c.call_variant.terminate()
             c.create_tensor.terminate()
             if need_realignment:
                 c.realign_reads.terminate()
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
 
         raise KeyboardInterrupt
     except Exception as e:
-        print("Exception received when waiting at CallVarBam, terminating all scripts.")
-        print(e)
+        print("Exception received when waiting at CallVarBam, terminating all scripts.", file=sys.stderr)
+        print(e, file=sys.stderr)
         try:
             c.call_variant.terminate()
             c.create_tensor.terminate()
             if need_realignment:
                 c.realign_reads.terminate()
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
 
         raise e
 

--- a/clair3/CallVariantsFromCffi.py
+++ b/clair3/CallVariantsFromCffi.py
@@ -210,7 +210,7 @@ def call_variants_from_cffi(args, output_config, output_utilities):
                 verbose=False
             )
         except Exception as e:
-            print("channel creation failed: " + str(e))
+            print("channel creation failed: " + str(e), file=sys.stderr)
             sys.exit()
     elif args.use_gpu:
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu_id) if args.gpu_id else ""
@@ -343,7 +343,7 @@ def call_variants_from_cffi(args, output_config, output_utilities):
                         result = future.result()
                         args.output_file.write(result)
                     except Exception as e:
-                        print(f"[Error] Task failed: {e}", flush=True)
+                        print(f"[Error] Task failed: {e}", flush=True, file=sys.stderr)
                         # Cleanup shared memory if worker failed before unlink
                         try:
                             orphan_shm = shared_memory.SharedMemory(name=shm_name)

--- a/clair3/CallVariantsFromCffiGPU.py
+++ b/clair3/CallVariantsFromCffiGPU.py
@@ -35,10 +35,10 @@ def check_gpu_memory(memory, device_ids=None, print_log=True):
         if print_log:
             print(f"GPU {device_id} free memory: {free_mem} MB, assigning {memory} MB per thread, {gpu_threads} threads available")
     if len(device_ids) == 0 or not detect_gpu:
-        print(log_error("No GPU available, Please disabling --use_gpu for variant calling, exiting."))
+        print(log_error("No GPU available, Please disabling --use_gpu for variant calling, exiting."), file=sys.stderr)
         sys.exit(1)
     if len(gpu_id_list) == 0:
-        print(log_error("No memory in GPU, Please assign GPU memory first, exiting."))
+        print(log_error("No memory in GPU, Please assign GPU memory first, exiting."), file=sys.stderr)
         sys.exit(1)
     return gpu_id_list
 
@@ -59,7 +59,7 @@ def Run(args):
 
     if args.device and args.device != "EMPTY":
         if not args.device.startswith('cuda:'):
-            print(log_error("Please specify the device as '--device=cuda:0' or '--device=cuda:0,1'"))
+            print(log_error("Please specify the device as '--device=cuda:0' or '--device=cuda:0,1'"), file=sys.stderr)
             sys.exit(1)
         device_ids = [int(x) for x in args.device.split("cuda:")[-1].split(",")]
         os.environ["CUDA_VISIBLE_DEVICES"] = ','.join([str(item) for item in device_ids])

--- a/postprocess/SwitchZygosityBasedOnSVCalls.py
+++ b/postprocess/SwitchZygosityBasedOnSVCalls.py
@@ -393,7 +393,7 @@ def Run(args):
             if use_sv_qual:
                 sv_qual = get_sv_qual(sv_input_variant_dict, sv_bed_tree, contig, ctg_name, int(pos))
                 if sv_qual is None:
-                    print("SV QUAL not found, skip switching QUAL!")
+                    print("SV QUAL not found, skip switching QUAL!", file=sys.stderr)
                     continue
                 columns = row_str.rstrip().split('\t')
                 clair3_qual = columns[5]

--- a/preprocess/CheckEnvs.py
+++ b/preprocess/CheckEnvs.py
@@ -58,13 +58,13 @@ def check_tools_version(tool_version, required_tool_version):
         if platform.system() == "Darwin" and tool == 'whatshap':
             continue
         if version is None:
-            print(log_error("[ERROR] {} not found, please check you are in clair3 virtual environment".format(tool)))
+            print(log_error("[ERROR] {} not found, please check you are in clair3 virtual environment".format(tool)), file=sys.stderr)
             check_python_path()
         elif version < required_version:
-            print(log_error("[ERROR] Tool version not match, please check you are in clair3 virtual environment"))
-            print(' '.join([str(item).ljust(10) for item in ["Tool", "Version", "Required"]]))
+            print(log_error("[ERROR] Tool version not match, please check you are in clair3 virtual environment"), file=sys.stderr)
+            print(' '.join([str(item).ljust(10) for item in ["Tool", "Version", "Required"]]), file=sys.stderr)
             error_info = ' '.join([str(item).ljust(10) for item in [tool, version, '>=' + str(required_version)]])
-            print(error_info)
+            print(error_info, file=sys.stderr)
             check_python_path()
     return
 
@@ -84,7 +84,7 @@ def check_contig_in_bam(bam_fn, sorted_contig_list, samtools):
     for contig_name in sorted_contig_list:
         if contig_name not in contig_with_read_support_set:
             print(log_warning(
-                "[WARNING] Contig name {} provided but no mapped reads in BAM, skip!".format(contig_name)))
+                "[WARNING] Contig name {} provided but no mapped reads in BAM, skip!".format(contig_name)), file=sys.stderr)
     filtered_sorted_contig_list = [item for item in sorted_contig_list if item in contig_with_read_support_set]
 
     found_contig = True
@@ -92,7 +92,7 @@ def check_contig_in_bam(bam_fn, sorted_contig_list, samtools):
         found_contig = False
         print(log_warning(
             "[WARNING] No mapped reads support in BAM for provided contigs set {}".format(
-                ' '.join(sorted_contig_list))))
+                ' '.join(sorted_contig_list))), file=sys.stderr)
     return filtered_sorted_contig_list, found_contig
 
 
@@ -233,7 +233,7 @@ def CheckEnvs(args):
     legal_range_from(param_name="indel_min_af", x=indel_min_af, min_num=0, max_num=1, exit_out_of_range=True)
     if ref_pct_full > 0.3:
         print(log_warning(
-            "[WARNING] For efficiency, we use a maximum 30% reference candidates for full-alignment calling"))
+            "[WARNING] For efficiency, we use a maximum 30% reference candidates for full-alignment calling"), file=sys.stderr)
     tool_version = {
         'python': LooseVersion(sys.version.split()[0]),
         'pypy': check_version(tool=pypy, pos=0, is_pypy=True),
@@ -256,10 +256,10 @@ def CheckEnvs(args):
     contig_set = set(ctg_name_list.split(',')) if is_ctg_name_list_provided else set()
 
     if is_ctg_name_list_provided and is_bed_file_provided:
-        print(log_warning("[WARNING] both --ctg_name and --bed_fn provided, will only proceed contigs in intersection"))
+        print(log_warning("[WARNING] both --ctg_name and --bed_fn provided, will only proceed contigs in intersection"), file=sys.stderr)
 
     if is_ctg_name_list_provided and is_known_vcf_file_provided:
-        print(log_warning("[WARNING] both --ctg_name and --vcf_fn provided, will only proceed contigs in intersection"))
+        print(log_warning("[WARNING] both --ctg_name and --vcf_fn provided, will only proceed contigs in intersection"), file=sys.stderr)
 
     if is_ctg_name_list_provided:
 
@@ -299,7 +299,7 @@ def CheckEnvs(args):
 
             if min_contig_size > 0 and contig_length < min_contig_size:
                 print(log_warning(
-                    "[WARNING] {} contig length {} is smaller than minimum contig size {}, will skip it!".format(contig_name, contig_length, min_contig_size)))
+                    "[WARNING] {} contig length {} is smaller than minimum contig size {}, will skip it!".format(contig_name, contig_length, min_contig_size)), file=sys.stderr)
                 if contig_name in contig_set:
                     contig_set.remove(contig_name)
                 continue
@@ -322,18 +322,18 @@ def CheckEnvs(args):
     if not len(contig_set):
         if is_bed_file_provided:
             all_contig_in_bed = ' '.join(list(tree.keys()))
-            print(log_warning("[WARNING] No contig intersection found by --bed_fn, contigs in BED {}: {}".format(bed_fn, all_contig_in_bed)))
+            print(log_warning("[WARNING] No contig intersection found by --bed_fn, contigs in BED {}: {}".format(bed_fn, all_contig_in_bed)), file=sys.stderr)
         if is_known_vcf_file_provided:
             all_contig_in_vcf = ' '.join(list(know_vcf_contig_set))
-            print(log_warning("[WARNING] No contig intersection found by --vcf_fn, contigs in VCF {}: {}".format(vcf_fn, all_contig_in_vcf)))
+            print(log_warning("[WARNING] No contig intersection found by --vcf_fn, contigs in VCF {}: {}".format(vcf_fn, all_contig_in_vcf)), file=sys.stderr)
         if is_ctg_name_list_provided:
             all_contig_in_ctg_name = ' '.join(ctg_name_list.split(','))
-            print(log_warning("[WARNING] No contig intersection found by --ctg_name, contigs in contigs list: {}".format(all_contig_in_ctg_name)))
+            print(log_warning("[WARNING] No contig intersection found by --ctg_name, contigs in contigs list: {}".format(all_contig_in_ctg_name)), file=sys.stderr)
         found_contig = False
     else:
         for c in sorted_contig_list:
             if c not in contig_chunk_num:
-                print(log_warning(("[WARNING] Contig {} given but not found in reference fai file".format(c))))
+                print(log_warning(("[WARNING] Contig {} given but not found in reference fai file".format(c))), file=sys.stderr)
 
         # check contig in bam have support reads
         sorted_contig_list, found_contig = check_contig_in_bam(bam_fn=bam_fn, sorted_contig_list=sorted_contig_list,
@@ -345,7 +345,7 @@ def CheckEnvs(args):
         output_header(output_fn=output_fn, reference_file_path=ref_fn, cmd_fn=cmd_fn, sample_name=sample_name)
         compress_index_vcf(output_fn)
         print(log_warning(
-            ("[WARNING] No contig intersection found, output header only in {}").format(output_fn + ".gz")))
+            ("[WARNING] No contig intersection found, output header only in {}").format(output_fn + ".gz")), file=sys.stderr)
         with open(contig_name_list, 'w') as output_file:
             output_file.write("")
         return
@@ -360,17 +360,17 @@ def CheckEnvs(args):
     if default_chunk_num > 0 and max_chunk_length > MAX_CHUNK_LENGTH:
         print(log_warning(
             '[WARNING] Current maximum chunk size {} is larger than default maximum chunk size {}, You may set a larger chunk_num by setting --chunk_num=$ for better parallelism.'.format(
-                min_chunk_length, MAX_CHUNK_LENGTH)))
+                min_chunk_length, MAX_CHUNK_LENGTH)), file=sys.stderr)
 
     elif default_chunk_num > 0 and min_chunk_length < MIN_CHUNK_LENGTH:
         print(log_warning(
             '[WARNING] Current minimum chunk size {} is smaller than default minimum chunk size {}, You may set a smaller chunk_num by setting --chunk_num=$.'.format(
-                min_chunk_length, MIN_CHUNK_LENGTH)))
+                min_chunk_length, MIN_CHUNK_LENGTH)), file=sys.stderr)
 
     if default_chunk_num == 0 and max(contig_length_list) < DEFAULT_CHUNK_SIZE / 5:
         print(log_warning(
             '[WARNING] Current maximum contig length {} is much smaller than default chunk size {}, You may set a smaller chunk size by setting --chunk_size=$ for better parallelism.'.format(
-                max(contig_length_list), DEFAULT_CHUNK_SIZE)))
+                max(contig_length_list), DEFAULT_CHUNK_SIZE)), file=sys.stderr)
 
     if is_bed_file_provided and default_chunk_num > -1:
         split_extend_bed(bed_fn=bed_fn, output_fn=split_bed_path, contig_set=contig_set)
@@ -478,7 +478,7 @@ def main():
     elif args.include_all_ctgs:
         print("[INFO] --include_all_ctgs enabled")
         if not args.no_phasing_for_fa:
-            print(log_warning("[WARNING] Please enable --no_phasing_for_fa if calling variant in non-diploid organisms"))
+            print(log_warning("[WARNING] Please enable --no_phasing_for_fa if calling variant in non-diploid organisms"), file=sys.stderr)
 
     CheckEnvs(args)
 

--- a/preprocess/CheckExitCode.py
+++ b/preprocess/CheckExitCode.py
@@ -16,12 +16,12 @@ def CheckExitCode(args):
 
     parallel_log_fn = args.parallel_log_fn
     if not os.path.exists(parallel_log_fn):
-        print(log_error("[ERROR] Parallel log file {} not found!".format(parallel_log_fn)))
+        print(log_error("[ERROR] Parallel log file {} not found!".format(parallel_log_fn)), file=sys.stderr)
         sys.exit(1)
     with open(parallel_log_fn, 'r') as log_file:
         log_lines = log_file.readlines()
     if len(log_lines) == 0:
-        print(log_warning("[WARNING] Parallel log file {} is empty!".format(parallel_log_fn)))
+        print(log_warning("[WARNING] Parallel log file {} is empty!".format(parallel_log_fn)), file=sys.stderr)
         sys.exit(0)
     header = log_lines[0].strip().split('\t')
     try:
@@ -29,7 +29,7 @@ def CheckExitCode(args):
         signal_idx = header.index("Signal")
         command_idx = header.index("Command")
     except ValueError as e:
-        print(log_error(f"[ERROR] Required columns not found in parallel log header: {e}"))
+        print(log_error(f"[ERROR] Required columns not found in parallel log header: {e}"), file=sys.stderr)
         sys.exit(1)
 
     has_failures = False
@@ -37,7 +37,7 @@ def CheckExitCode(args):
     for line_num, line in enumerate(log_lines[1:], start=2):
         fields = line.strip().split('\t')
         if len(fields) <= max(exitval_idx, signal_idx, command_idx):
-            print(log_warning(f"[WARNING] Line {line_num} has insufficient columns, skipping"))
+            print(log_warning(f"[WARNING] Line {line_num} has insufficient columns, skipping"), file=sys.stderr)
             continue
 
         exitval = fields[exitval_idx]
@@ -50,10 +50,10 @@ def CheckExitCode(args):
                 f"\n[ERROR] Command failed: {command}\n"
                 f"Exit status: {exitval}, Signal: {signal}\n"
                 f"{'-' * 80}"
-            ))
+            ), file=sys.stderr)
 
     if has_failures:
-        print(log_error("\n[ERROR] Some parallel jobs failed (see above for details)"))
+        print(log_error("\n[ERROR] Some parallel jobs failed (see above for details)"), file=sys.stderr)
         sys.exit(1)
     else:
         sys.exit(0)

--- a/preprocess/CreateTrainingTensor.py
+++ b/preprocess/CreateTrainingTensor.py
@@ -75,7 +75,7 @@ def Run(args):
         bam_fn = file_path_from(args.bam_fn)
         if bam_fn is None or bam_fn == "":
             print(log_warning(
-                "[WARNING] Skip full-alignment variant calling for empty full-alignment regions"))
+                "[WARNING] Skip full-alignment variant calling for empty full-alignment regions"), file=sys.stderr)
             return
     ref_fn = file_path_from(args.ref_fn, exit_on_not_found=True)
     bed_fn = file_path_from(args.bed_fn)
@@ -189,22 +189,22 @@ def Run(args):
         c.create_tensor.stdout.close()
         c.create_tensor.wait()
     except KeyboardInterrupt as e:
-        print("KeyboardInterrupt received when waiting at Tensor2Bin, terminating all scripts.")
+        print("KeyboardInterrupt received when waiting at Tensor2Bin, terminating all scripts.", file=sys.stderr)
         try:
             c.compress_tensor.terminate()
             c.create_tensor.terminate()
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
 
         raise KeyboardInterrupt
     except Exception as e:
-        print("Exception received when waiting at CreateTensor, terminating all scripts.")
-        print(e)
+        print("Exception received when waiting at CreateTensor, terminating all scripts.", file=sys.stderr)
+        print(e, file=sys.stderr)
         try:
             c.compress_tensor.terminate()
             c.create_tensor.terminate()
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
 
         raise e
 

--- a/preprocess/SelectCandidates.py
+++ b/preprocess/SelectCandidates.py
@@ -34,7 +34,7 @@ def print_calling_step(output_fn=""):
     merge_output = os.path.join(os.path.dirname(output_fn), 'merge_output.vcf.gz')
     pileup_output = os.path.join(os.path.dirname(output_fn), 'pileup.vcf.gz')
 
-    print (log_warning("[WARNING] Copying pileup.vcf.gz to {}".format(merge_output)))
+    print (log_warning("[WARNING] Copying pileup.vcf.gz to {}".format(merge_output)), file=sys.stderr)
     subprocess.run('cp {} {}'.format(pileup_output, merge_output), shell=True, stdout=subprocess.PIPE,
                    stderr=subprocess.PIPE)
 
@@ -250,7 +250,7 @@ def SelectCandidates(args):
 
             if len(need_phasing_row_list) == 0:
                 print(log_warning(
-                    "[WARNING] Cannot find any low-quality 0/0, 0/1 or 1/1 variant in pileup output in contig {}".format(contig_name)))
+                    "[WARNING] Cannot find any low-quality 0/0, 0/1 or 1/1 variant in pileup output in contig {}".format(contig_name)), file=sys.stderr)
 
             region_num = len(need_phasing_row_list) // split_bed_size + 1 if len(
                 need_phasing_row_list) % split_bed_size else len(need_phasing_row_list) // split_bed_size

--- a/preprocess/SelectQual.py
+++ b/preprocess/SelectQual.py
@@ -1,3 +1,4 @@
+import sys
 from sys import stdin
 from argparse import ArgumentParser, SUPPRESS
 import os
@@ -36,8 +37,8 @@ def select_phase_qual_from_stdin(args):
     if len(low_phase_qual_list) == 0:
         print(log_warning(
             "[WARNING] Cannot find any 0/1 variant in pileup output using variant quality cut-off proportion: {}, total heterozygous variants: {}".format(
-                low_qual_hete_var_pct, len(low_phase_qual_list))))
-        print(log_warning("[WARNING] Set low variant quality score cut-off to 0.0"))
+                low_qual_hete_var_pct, len(low_phase_qual_list))), file=sys.stderr)
+        print(log_warning("[WARNING] Set low variant quality score cut-off to 0.0"), file=sys.stderr)
         qual_cut_off = 0.0
     else:
         qual_cut_off = low_phase_qual_list[-1]
@@ -87,8 +88,8 @@ def select_qual_from_stdin(args):
     if len(low_variant_qual_list) == 0:
         print(log_warning(
             "[WARNING] Cannot find any low-quality 0/1 or 1/1 variant in pileup output using variant quality cut-off proportion: {}, total variants: {}".format(
-                var_pct_full, len(variant_qual_list))))
-        print(log_warning("[WARNING] Set low variant quality score cut-off to 0.0"))
+                var_pct_full, len(variant_qual_list))), file=sys.stderr)
+        print(log_warning("[WARNING] Set low variant quality score cut-off to 0.0"), file=sys.stderr)
         var_qual_cut_off = 0.0
     else:
         var_qual_cut_off = low_variant_qual_list[-1]
@@ -98,8 +99,8 @@ def select_qual_from_stdin(args):
     if len(low_ref_qual_list) == 0:
         print(log_warning(
             "[WARNING] Cannot find any low-quality 0/0 reference calls in pileup output using reference quality cut-off proportion: {}, total reference calls: {}".format(
-                ref_pct_full, len(ref_qual_list))))
-        print(log_warning("[WARNING] Set low reference quality score cut-off to 0.0"))
+                ref_pct_full, len(ref_qual_list))), file=sys.stderr)
+        print(log_warning("[WARNING] Set low reference quality score cut-off to 0.0"), file=sys.stderr)
         ref_qual_cut_off = 0.0
     else:
         ref_qual_cut_off = low_ref_qual_list[-1]

--- a/preprocess/SortVcf.py
+++ b/preprocess/SortVcf.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import shlex
+import sys
 from sys import stdin, exit
 from argparse import ArgumentParser
 from collections import defaultdict
@@ -37,7 +38,7 @@ def print_calling_step(output_fn=""):
     merge_output = os.path.join(os.path.dirname(output_fn), 'merge_output.vcf.gz')
     pileup_output = os.path.join(os.path.dirname(output_fn), 'pileup.vcf.gz')
 
-    print (log_warning("[WARNING] Copying pileup.vcf.gz to {}".format(merge_output)))
+    print (log_warning("[WARNING] Copying pileup.vcf.gz to {}".format(merge_output)), file=sys.stderr)
     subprocess.run('cp {} {}'.format(pileup_output, merge_output), shell=True, stdout=subprocess.PIPE,
                    stderr=subprocess.PIPE)
 
@@ -58,7 +59,7 @@ def check_header_in_gvcf(header, contigs_list):
 def check_malformed_records(row, file, contig=None, check_header=False, sample_name=None):
     if check_header:
         if row.startswith("#CHROM") and len(row.split('\t')) != 10:
-            print(log_warning("[WARNING] Malformed header line:\n {} in {}, split into two lines").format(row, file))
+            print(log_warning("[WARNING] Malformed header line:\n {} in {}, split into two lines").format(row, file), file=sys.stderr)
             if sample_name is not None:
                 # add sample name to the header
                 chr_pos = row.find(sample_name) + len(sample_name)
@@ -81,10 +82,10 @@ def check_malformed_records(row, file, contig=None, check_header=False, sample_n
             return row, None
         if len(row.split('\t')) > 19:
             #multiple malformed, skip the row
-            print(log_warning("[WARNING] Malformed header line:\n {} in {}, skip!").format(row, file))
+            print(log_warning("[WARNING] Malformed header line:\n {} in {}, skip!").format(row, file), file=sys.stderr)
             return None, None
         else:
-            print(log_warning("[WARNING] Malformed VCF line:\n {} in {}, split into two lines").format(row, file))
+            print(log_warning("[WARNING] Malformed VCF line:\n {} in {}, split into two lines").format(row, file), file=sys.stderr)
             #the second position
             chr_pos = row[len(contig):].find(contig) + len(contig)
             first_row = row[:chr_pos] + '\n'
@@ -133,9 +134,9 @@ def sort_vcf_from_stdin(args):
         contig_dict[ctg_name][int(pos)] = row
         no_vcf_output = False
     if row_count == 0:
-        print(log_warning("[WARNING] No vcf file found, please check the setting"))
+        print(log_warning("[WARNING] No vcf file found, please check the setting"), file=sys.stderr)
     if no_vcf_output:
-        print(log_warning("[WARNING] No variant found, please check the setting"))
+        print(log_warning("[WARNING] No variant found, please check the setting"), file=sys.stderr)
 
     contigs_order = major_contigs_order + list(contig_dict.keys())
     contigs_order_list = sorted(contig_dict.keys(), key=lambda x: contigs_order.index(x))
@@ -170,7 +171,7 @@ def sort_vcf_from(args):
         if len(all_files) == 0:
             output_header(output_fn=output_fn, reference_file_path=ref_fn, cmd_fn=cmd_fn, sample_name=sample_name)
             print (log_warning(
-                "[WARNING] No vcf file found with prefix:{}/{}, output empty vcf file".format(input_dir,vcf_fn_prefix)))
+                "[WARNING] No vcf file found with prefix:{}/{}, output empty vcf file".format(input_dir,vcf_fn_prefix)), file=sys.stderr)
             compress_index_vcf(output_fn)
             print_calling_step(output_fn=output_fn)
             return
@@ -180,7 +181,7 @@ def sort_vcf_from(args):
         if len(all_files) == 0:
             output_header(output_fn=output_fn, reference_file_path=ref_fn, cmd_fn=cmd_fn, sample_name=sample_name)
             print (log_warning(
-                "[WARNING] No vcf file found with suffix:{}/{}, output empty vcf file".format(input_dir,vcf_fn_prefix)))
+                "[WARNING] No vcf file found with suffix:{}/{}, output empty vcf file".format(input_dir,vcf_fn_prefix)), file=sys.stderr)
             compress_index_vcf(output_fn)
             print_calling_step(output_fn=output_fn)
             return
@@ -369,14 +370,14 @@ def sort_vcf_from(args):
         output.close()
 
     if row_count == 0:
-        print (log_warning("[WARNING] No vcf file found, output empty vcf file"))
+        print (log_warning("[WARNING] No vcf file found, output empty vcf file"), file=sys.stderr)
         output_header(output_fn=output_fn, reference_file_path=ref_fn, cmd_fn=cmd_fn, sample_name=sample_name)
         compress_index_vcf(output_fn)
         print_calling_step(output_fn=output_fn)
         return
     if no_vcf_output:
         output_header(output_fn=output_fn, reference_file_path=ref_fn, cmd_fn=cmd_fn, sample_name=sample_name)
-        print (log_warning("[WARNING] No variant found, output empty vcf file"))
+        print (log_warning("[WARNING] No variant found, output empty vcf file"), file=sys.stderr)
         compress_index_vcf(output_fn)
         print_calling_step(output_fn=output_fn)
         return

--- a/preprocess/utils.py
+++ b/preprocess/utils.py
@@ -327,7 +327,7 @@ class gvcfGenerator(object):
 
             else:
                 print("[ERROR] CurVarStart", curVarStart, 'curVarEnd', curVarEnd, 'curNonVarStart', curNonVarStart,
-                      'curNonVarEnd', curNonVarEnd)
+                      'curNonVarEnd', curNonVarEnd, file=sys.stderr)
 
         # printout the remain content
         if (not varCallStop):

--- a/run_clair3.py
+++ b/run_clair3.py
@@ -93,12 +93,12 @@ def parse_args():
 
 
 def error_exit(msg):
-    print(f"{ERROR} {msg}")
+    print(f"{ERROR} {msg}", file=sys.stderr)
     raise SystemExit(1)
 
 
 def warn(msg):
-    print(f"{WARNING} {msg}")
+    print(f"{WARNING} {msg}", file=sys.stderr)
 
 
 def file_exists(path):
@@ -281,17 +281,17 @@ def main():
     output_folder = Path(args.output)
 
     if not bam_path.is_absolute() and bam_path.is_file():
-        bam_path = bam_path.resolve()
+        bam_path = bam_path.absolute()
     if not ref_path.is_absolute() and ref_path.is_file():
-        ref_path = ref_path.resolve()
+        ref_path = ref_path.absolute()
     if not model_path.is_absolute() and model_path.is_dir():
         model_path = model_path.resolve()
     bed_path = Path(args.bed_fn) if args.bed_fn != "EMPTY" else None
     vcf_path = Path(args.vcf_fn) if args.vcf_fn != "EMPTY" else None
     if bed_path and not bed_path.is_absolute() and bed_path.is_file():
-        bed_path = bed_path.resolve()
+        bed_path = bed_path.absolute()
     if vcf_path and not vcf_path.is_absolute() and vcf_path.is_file():
-        vcf_path = vcf_path.resolve()
+        vcf_path = vcf_path.absolute()
     if not output_folder.is_absolute():
         warn("No absolute output path provided, using current directory as prefix")
         output_folder = (cwd / output_folder).resolve()

--- a/scripts/clair3.sh
+++ b/scripts/clair3.sh
@@ -11,7 +11,7 @@ min_mq::,min_coverage::,min_contig_size::,snp_min_af::,indel_min_af::,ref_pct_fu
 use_whatshap_for_intermediate_phasing::,use_longphase_for_intermediate_phasing::,use_whatshap_for_final_output_phasing::,use_longphase_for_final_output_phasing::,use_whatshap_for_final_output_haplotagging::,keep_iupac_bases::,\
 no_phasing_for_fa::,pileup_model_prefix::,fa_model_prefix::,call_snp_only::,enable_variant_calling_at_sequence_head_and_tail::,output_all_contigs_in_gvcf_header::,remove_intermediate_dir::,enable_phasing::,enable_long_indel::,use_gpu::,longphase_for_phasing::,longphase::,base_err::,gq_bin_size::,enable_dwell_time:: -n 'run_clair3.sh' -- "$@"`
 
-if [ $? != 0 ] ; then echo"No input. Terminating...">&2 ; exit 1 ; fi
+if [ $? != 0 ] ; then echo "No input. Terminating..." >&2 ; exit 1 ; fi
 eval set -- "${ARGS}"
 
 while true; do

--- a/scripts/clair3_c_impl.sh
+++ b/scripts/clair3_c_impl.sh
@@ -11,7 +11,7 @@ min_mq::,min_coverage::,min_contig_size::,snp_min_af::,indel_min_af::,ref_pct_fu
 use_whatshap_for_intermediate_phasing::,use_longphase_for_intermediate_phasing::,use_whatshap_for_final_output_phasing::,use_longphase_for_final_output_phasing::,use_whatshap_for_final_output_haplotagging::,keep_iupac_bases::,\
 no_phasing_for_fa::,pileup_model_prefix::,fa_model_prefix::,call_snp_only::,enable_variant_calling_at_sequence_head_and_tail::,output_all_contigs_in_gvcf_header::,remove_intermediate_dir::,enable_phasing::,enable_long_indel::,use_gpu::,longphase_for_phasing::,longphase::,base_err::,gq_bin_size::,enable_dwell_time:: -n 'run_clair3.sh' -- "$@"`
 
-if [ $? != 0 ] ; then echo"No input. Terminating...">&2 ; exit 1 ; fi
+if [ $? != 0 ] ; then echo "No input. Terminating..." >&2 ; exit 1 ; fi
 eval set -- "${ARGS}"
 
 while true; do


### PR DESCRIPTION
Currently Clair3 fails when a reference FASTA is provided as a symlink if the reference index (`.fai`) is relative to the symlink since it looks at the resolved path rather than the local one, this PR fixes that and fixes up a bunch of error prints which go to stdout rather than error.