### PR TITLE
Replace shell gzip with pigz

### DIFF
--- a/clair3/metrics/GetOverallMetrics.py
+++ b/clair3/metrics/GetOverallMetrics.py
@@ -32,7 +32,7 @@ def Cal(args):
         output_file = open(output_fn, 'w')
     else:
         output_file = None
-    happy_vcf_unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (happy_vcf_fn)))
+    happy_vcf_unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (happy_vcf_fn)))
 
     truth_all_tp, query_all_tp, query_all_fp, truth_all_fn = 0, 0, 0, 0
     truth_snp_tp, query_snp_tp, query_snp_fp, truth_snp_fn = 0, 0, 0, 0

--- a/clair3/utils.py
+++ b/clair3/utils.py
@@ -188,7 +188,7 @@ def variant_map_from(var_fn, tree, is_tree_empty):
     if var_fn is None:
         return Y, miss_variant_set, truth_alt_dict
 
-    f = subprocess_popen(shlex.split("gzip -fdc %s" % (var_fn)))
+    f = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (var_fn)))
     for row in f.stdout:
         if row[0] == "#":
             continue

--- a/postprocess/AddBackMissingVariantsInGenotyping.py
+++ b/postprocess/AddBackMissingVariantsInGenotyping.py
@@ -70,7 +70,7 @@ class VcfReader(object):
             vcf_fp = open(self.vcf_fn)
             vcf_fo = vcf_fp
         else:
-            vcf_fp = subprocess_popen(shlex.split("gzip -fdc %s" % (self.vcf_fn)))
+            vcf_fp = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (self.vcf_fn)))
             vcf_fo = vcf_fp.stdout
         for row in vcf_fo:
             columns = row.strip().split()

--- a/postprocess/AddPairEndAlleleDepth.py
+++ b/postprocess/AddPairEndAlleleDepth.py
@@ -132,7 +132,7 @@ class VcfReader(object):
             vcf_fp = open(self.vcf_fn)
             vcf_fo = vcf_fp
         else:
-            vcf_fp = subprocess_popen(shlex.split("gzip -fdc %s" % (self.vcf_fn)))
+            vcf_fp = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (self.vcf_fn)))
             vcf_fo = vcf_fp.stdout
         for row in vcf_fo:
             columns = row.strip().split()

--- a/postprocess/SwitchZygosityBasedOnSVCalls.py
+++ b/postprocess/SwitchZygosityBasedOnSVCalls.py
@@ -148,7 +148,7 @@ class VcfReader(object):
             vcf_fp = open(self.vcf_fn)
             vcf_fo = vcf_fp
         else:
-            vcf_fp = subprocess_popen(shlex.split("gzip -fdc %s" % (self.vcf_fn)))
+            vcf_fp = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (self.vcf_fn)))
             vcf_fo = vcf_fp.stdout
         for row in vcf_fo:
             columns = row.strip().split()

--- a/preprocess/CheckEnvs.py
+++ b/preprocess/CheckEnvs.py
@@ -99,7 +99,7 @@ def check_contig_in_bam(bam_fn, sorted_contig_list, samtools):
 def split_extend_vcf(vcf_fn, output_fn):
     expand_region_size = param.no_of_positions
     output_ctg_dict = defaultdict(list)
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
 
     for row_id, row in enumerate(unzip_process.stdout):
         if row[0] == '#':
@@ -136,7 +136,7 @@ def split_extend_vcf(vcf_fn, output_fn):
 def split_extend_bed(bed_fn, output_fn, contig_set=None):
     expand_region_size = param.no_of_positions
     output_ctg_dict = defaultdict(list)
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (bed_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (bed_fn)))
     for row_id, row in enumerate(unzip_process.stdout):
         if row[0] == '#':
             continue

--- a/preprocess/CreateTensorFullAlignment.py
+++ b/preprocess/CreateTensorFullAlignment.py
@@ -626,7 +626,7 @@ def CreateTensorFullAlignment(args):
         haplotag, which is faster than whatshap haplotag with more memory occupation.
         """
 
-        candidate_file_path_process = subprocess_popen(shlex.split("gzip -fdc %s" % (full_aln_regions)))
+        candidate_file_path_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (full_aln_regions)))
         candidate_file_path_output = candidate_file_path_process.stdout
 
         ctg_start, ctg_end = float('inf'), 0
@@ -706,7 +706,7 @@ def CreateTensorFullAlignment(args):
 
     if need_phasing and phased_vcf_fn and os.path.exists(phased_vcf_fn):
         # if need_phasing option enables, scan the phased vcf file and store the heterozygous snp candidates from each phase set
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (phased_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (phased_vcf_fn)))
         for row in unzip_process.stdout:
             row = row.rstrip()
             if row[0] == '#':

--- a/preprocess/CreateTensorFullAlignmentFromCffi.py
+++ b/preprocess/CreateTensorFullAlignmentFromCffi.py
@@ -80,7 +80,7 @@ def CreateTensorFullAlignment(args):
     variant_list = []
     if need_haplotagging and phased_vcf_fn and os.path.exists(phased_vcf_fn):
         # if need_haplotagging option enables, scan the phased vcf file and store the heterozygous SNP candidates from each phase set
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (phased_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (phased_vcf_fn)))
         for row in unzip_process.stdout:
             row = row.rstrip()
             if row[0] == '#':

--- a/preprocess/CreateTensorFullAlignmentFromCffiWithDwell.py
+++ b/preprocess/CreateTensorFullAlignmentFromCffiWithDwell.py
@@ -99,7 +99,7 @@ def CreateTensorFullAlignment(args):
     variant_list = []
     if need_haplotagging and phased_vcf_fn and os.path.exists(phased_vcf_fn):
         # if need_haplotagging option enables, scan the phased vcf file and store the heterozygous SNP candidates from each phase set
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (phased_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (phased_vcf_fn)))
         for row in unzip_process.stdout:
             row = row.rstrip()
             if row[0] == '#':

--- a/preprocess/CreateTrainingTensorDirect.py
+++ b/preprocess/CreateTrainingTensorDirect.py
@@ -48,7 +48,7 @@ def variant_map_from(var_fn, tree, is_tree_empty):
     if var_fn is None:
         return Y, miss_variant_set, truth_alt_dict
 
-    f = subprocess_popen(shlex.split("gzip -fdc %s" % (var_fn)))
+    f = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (var_fn)))
     for row in f.stdout:
         if row[0] == "#":
             continue
@@ -320,7 +320,7 @@ def create_training_tensor_fa(args):
     # --- Step 3: Parse phased VCF → Variant structs for C haplotagging ---
     variant_list = []
     if need_haplotagging and phased_vcf_fn and os.path.exists(phased_vcf_fn):
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (phased_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (phased_vcf_fn)))
         for row in unzip_process.stdout:
             row = row.rstrip()
             if row[0] == '#':

--- a/preprocess/GetTruth.py
+++ b/preprocess/GetTruth.py
@@ -25,13 +25,13 @@ def OutputVariant(args):
         truth_vcf_set = set(vcf_candidates_from(vcf_fn=truth_vcf_fn, contig_name=ctg_name))
     if args.var_fn != "PIPE":
         var_fpo = open(var_fn, "wb")
-        var_fp = subprocess_popen(shlex.split("gzip -c"), stdin=PIPE, stdout=var_fpo)
+        var_fp = subprocess_popen(shlex.split("pigz -c -p 2"), stdin=PIPE, stdout=var_fpo)
     else:
         var_fp = TruthStdout(sys.stdout)
 
     is_ctg_region_provided = ctg_start is not None and ctg_end is not None
 
-    vcf_fp = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+    vcf_fp = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
 
     for row in vcf_fp.stdout:
         columns = row.strip().split()

--- a/preprocess/MergeVcf.py
+++ b/preprocess/MergeVcf.py
@@ -82,7 +82,7 @@ def MergeVcf_illumina(args):
     print_ref = args.print_ref_calls
 
     tree = bed_tree_from(bed_file_path=bed_fn, padding=param.no_of_positions, contig_name=contig_name)
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (pileup_vcf_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (pileup_vcf_fn)))
     output_dict = {}
     header = []
     pileup_count = 0
@@ -116,7 +116,7 @@ def MergeVcf_illumina(args):
     unzip_process.stdout.close()
     unzip_process.wait()
 
-    realigned_vcf_unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (full_alignment_vcf_fn)))
+    realigned_vcf_unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (full_alignment_vcf_fn)))
     realiged_read_num = 0
     for row in realigned_vcf_unzip_process.stdout:
         if row[0] == '#':
@@ -169,7 +169,7 @@ def MergeVcf(args):
     is_haploid_precise_mode_enabled = args.haploid_precise
     is_haploid_sensitive_mode_enabled = args.haploid_sensitive
     print_ref = args.print_ref_calls
-    full_alignment_vcf_unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (full_alignment_vcf_fn)))
+    full_alignment_vcf_unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (full_alignment_vcf_fn)))
 
     full_alignment_output = []
     full_alignment_output_set = set()
@@ -205,7 +205,7 @@ def MergeVcf(args):
     full_alignment_vcf_unzip_process.stdout.close()
     full_alignment_vcf_unzip_process.wait()
 
-    pileup_vcf_unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (pileup_vcf_fn)))
+    pileup_vcf_unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (pileup_vcf_fn)))
 
     output_file = open(output_fn, 'w')
     output_file.write(''.join(header))

--- a/preprocess/RealignReads.py
+++ b/preprocess/RealignReads.py
@@ -339,7 +339,7 @@ def reads_realignment(args):
     global test_pos
     test_pos = None
     if is_bed_file_given:
-        candidate_file_path_process = subprocess_popen(shlex.split("gzip -fdc %s" % (bed_file_path)))
+        candidate_file_path_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (bed_file_path)))
         candidate_file_path_output = candidate_file_path_process.stdout
 
         ctg_start, ctg_end = float('inf'), 0

--- a/preprocess/SelectCandidates.py
+++ b/preprocess/SelectCandidates.py
@@ -167,7 +167,7 @@ def SelectCandidates(args):
 
     all_full_aln_regions = []
     if phased_vcf_fn and os.path.exists(phased_vcf_fn):
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (phased_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (phased_vcf_fn)))
         for row in unzip_process.stdout:
             row = row.rstrip()
             if row[0] == '#':
@@ -188,7 +188,7 @@ def SelectCandidates(args):
 
     if pileup_vcf_fn and os.path.exists(pileup_vcf_fn):
         # vcf format
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (pileup_vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (pileup_vcf_fn)))
         for row in unzip_process.stdout:
             if row[0] == '#':
                 continue
@@ -299,7 +299,7 @@ def SelectCandidates(args):
 
     # Call variant in all candidate position
     elif args.all_alt_fn is not None:
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (args.all_alt_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (args.all_alt_fn)))
         for row in unzip_process.stdout:
             if row[0] == '#':
                 continue

--- a/preprocess/SelectHetSnp.py
+++ b/preprocess/SelectHetSnp.py
@@ -31,7 +31,7 @@ def FiterHeteSnpPhasing(args):
         phase_qual_cut_off = float(open(f_qual, 'r').read().rstrip())
         found_qual_cut_off = True
 
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
     for row in unzip_process.stdout:
         row = row.rstrip()
         if row[0] == '#':
@@ -89,7 +89,7 @@ def FiterHeteSnp_FP(args):
     chr_prefix = args.chr_prefix
     contig_name = args.ctgName
     phasing_window_size = param.phasing_window_size
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
     split_bed_size = args.split_bed_size
     split_folder = args.split_folder
     output = []
@@ -188,7 +188,7 @@ def FiterHeteSnp(args):
     candidate_positions = set()
 
     if vcf_fn and os.path.exists(vcf_fn):
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
         for row in unzip_process.stdout:
             row =row.rstrip()
             if row[0] == '#':
@@ -209,7 +209,7 @@ def FiterHeteSnp(args):
 
     if alt_fn is not None:
         # vcf format
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (alt_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (alt_fn)))
         for row in unzip_process.stdout:
             if row[0] == '#':
                 continue
@@ -283,7 +283,7 @@ def FiterHeteSnp(args):
 
     # train or call in all_pos
     elif args.all_alt_fn is not None:
-        unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (args.all_alt_fn)))
+        unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (args.all_alt_fn)))
         for row in unzip_process.stdout:
             if row[0] == '#':
                 continue

--- a/preprocess/SplitExtendBed.py
+++ b/preprocess/SplitExtendBed.py
@@ -20,7 +20,7 @@ def split_extend_bed(args):
     if bed_fn is None:
         return
     output = []
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (bed_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (bed_fn)))
     pre_end, pre_start = -1, -1
 
     for row in unzip_process.stdout:

--- a/preprocess/UnifyRepresentation.py
+++ b/preprocess/UnifyRepresentation.py
@@ -1010,7 +1010,7 @@ class RepresentationUnification(object):
 
 def parse_candidates_file(candidate_details_fn, contig_name=None):
     candidate_details_list = []
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % candidate_details_fn))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % candidate_details_fn))
     for row in unzip_process.stdout:
         candidate_details_list.append(row)
     return candidate_details_list
@@ -1142,7 +1142,7 @@ def UnifyRepresentation(args):
         regions=ref_regions
     )
 
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (var_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (var_fn)))
     variant_dict = defaultdict(list)
     for row in unzip_process.stdout:
         if row[0] == '#':

--- a/scripts/clair3.sh
+++ b/scripts/clair3.sh
@@ -197,7 +197,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --qual ${QUAL} \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in pileup variant calling"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in pileup variant calling"; exit 0; fi
 if [ ${PILEUP_ONLY} == True ]; then
     if [ ${RM_TMP_DIR} == True ]; then echo "[INFO] Removing intermediate files in ${OUTPUT_FOLDER}/tmp"; rm -rf ${OUTPUT_FOLDER}/tmp; fi
     echo "[INFO] Only call pileup output with --pileup_only, output file: ${OUTPUT_FOLDER}/pileup.vcf.gz"
@@ -216,7 +216,7 @@ then
 else
     echo $''
     echo "[INFO] 2/7 Select heterozygous SNP variants for Whatshap phasing and haplotagging"
-    gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --phase --output_fn ${PHASE_VCF_PATH} --var_pct_phasing ${PHASING_PCT}
+    pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --phase --output_fn ${PHASE_VCF_PATH} --var_pct_phasing ${PHASING_PCT}
     time ${PARALLEL} --retries ${RETRIES} --joblog ${LOG_PATH}/parallel_2_select_hetero_snp.log -j${THREADS} \
     "${PYPY} ${CLAIR3} SelectHetSnp \
         --vcf_fn ${OUTPUT_FOLDER}/pileup.vcf.gz \
@@ -271,7 +271,7 @@ fi
 #-----------------------------------------------------------------------------------------------------------------------
 echo $''
 echo "[INFO] 5/7 Select candidates for full-alignment calling"
-gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --output_fn ${CANDIDATE_BED_PATH} \
+pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --output_fn ${CANDIDATE_BED_PATH} \
 --var_pct_full ${PRO} --ref_pct_full ${REF_PRO} --platform ${PLATFORM} --vcf_fn ${VCF_FILE_PATH}
 time ${PARALLEL} --retries ${RETRIES} --joblog ${LOG_PATH}/parallel_5_select_candidate.log -j${THREADS} \
 "${PYPY} ${CLAIR3} SelectCandidates \
@@ -321,7 +321,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --ref_fn ${REFERENCE_FILE_PATH} \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/full_alignment.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in full-alignment variant calling"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/full_alignment.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in full-alignment variant calling"; exit 0; fi
 # Compress GVCF output using lz4
 if [ ${GVCF} == True ]
 then
@@ -366,7 +366,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --cmd_fn ${OUTPUT_FOLDER}/tmp/CMD \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/merge_output.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in variant merging"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/merge_output.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in variant merging"; exit 0; fi
 if [ ${GVCF} == True ]
 then
     ${PYPY} ${CLAIR3} SortVcf \

--- a/scripts/clair3_c_impl.sh
+++ b/scripts/clair3_c_impl.sh
@@ -247,7 +247,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --use_gpu ${USE_GPU} \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in pileup variant calling"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in pileup variant calling"; exit 0; fi
 if [ ${PILEUP_ONLY} = True ]; then
     if [ ${RM_TMP_DIR} = True ]; then echo "[INFO] Removing intermediate files in ${OUTPUT_FOLDER}/tmp"; rm -rf ${OUTPUT_FOLDER}/tmp; fi
     echo "[INFO] Only call pileup output with --pileup_only, output file: ${OUTPUT_FOLDER}/pileup.vcf.gz"
@@ -266,7 +266,7 @@ then
 else
     echo $''
     echo "[INFO] 2/7 Select heterozygous SNP variants for Whatshap phasing and haplotagging"
-    gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --phase --output_fn ${PHASE_VCF_PATH} --var_pct_phasing ${PHASING_PCT}
+    pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --phase --output_fn ${PHASE_VCF_PATH} --var_pct_phasing ${PHASING_PCT}
     time ${PARALLEL} --retries ${RETRIES} --joblog ${LOG_PATH}/parallel_2_select_hetero_snp.log -j${THREADS} \
     "${PYPY} ${CLAIR3} SelectHetSnp \
         --vcf_fn ${OUTPUT_FOLDER}/pileup.vcf.gz \
@@ -308,7 +308,7 @@ fi
 #-----------------------------------------------------------------------------------------------------------------------
 echo $''
 echo "[INFO] 5/7 Select candidates for full-alignment calling"
-gzip -fdc ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --output_fn ${CANDIDATE_BED_PATH} \
+pigz -fdc -p 2 ${OUTPUT_FOLDER}/pileup.vcf.gz | ${PYPY} ${CLAIR3} SelectQual --output_fn ${CANDIDATE_BED_PATH} \
 --var_pct_full ${PRO} --ref_pct_full ${REF_PRO} --platform ${PLATFORM} --vcf_fn ${VCF_FILE_PATH}
 time ${PARALLEL} --retries ${RETRIES} --joblog ${LOG_PATH}/parallel_5_select_candidate.log -j${THREADS} \
 "${PYPY} ${CLAIR3} SelectCandidates \
@@ -391,7 +391,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --use_gpu ${USE_GPU} \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/full_alignment.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in full-alignment variant calling"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/full_alignment.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in full-alignment variant calling"; exit 0; fi
 # Compress GVCF output using lz4
 if [ ${GVCF} = True ]
 then
@@ -436,7 +436,7 @@ ${PYPY} ${CLAIR3} SortVcf \
     --cmd_fn ${OUTPUT_FOLDER}/tmp/CMD \
     --contigs_fn ${TMP_FILE_PATH}/CONTIGS
 
-if [ "$( gzip -fdc ${OUTPUT_FOLDER}/merge_output.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in variant merging"; exit 0; fi
+if [ "$( pigz -fdc -p 2 ${OUTPUT_FOLDER}/merge_output.vcf.gz | grep -v '#' | wc -l )" -eq 0 ]; then echo "[INFO] Exit in variant merging"; exit 0; fi
 if [ ${GVCF} = True ]
 then
     ${PYPY} ${CLAIR3} SortVcf \

--- a/scripts/clair3_c_impl_pipeline.py
+++ b/scripts/clair3_c_impl_pipeline.py
@@ -384,7 +384,7 @@ def main():
         print("")
         print("[INFO] 2/7 Select heterozygous SNP variants for Whatshap phasing and haplotagging")
         run_command(
-            f"gzip -fdc {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
+            f"pigz -fdc -p 2 {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
             f"--phase --output_fn {q(phase_vcf_path)} --var_pct_phasing {q(args.var_pct_phasing)}",
             log_path=log_path / "2_select_hetero_snp.log",
         )
@@ -444,7 +444,7 @@ def main():
     print("")
     print("[INFO] 5/7 Select candidates for full-alignment calling")
     run_command(
-        f"gzip -fdc {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
+        f"pigz -fdc -p 2 {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
         f"--output_fn {q(candidate_bed_path)} --var_pct_full {q(args.var_pct_full)} "
         f"--ref_pct_full {q(args.ref_pct_full)} --platform {q(args.platform)} --vcf_fn {q(args.vcf_fn)}",
         log_path=log_path / "5_select_candidate.log",

--- a/scripts/clair3_pipeline.py
+++ b/scripts/clair3_pipeline.py
@@ -334,7 +334,7 @@ def main():
         print("")
         print("[INFO] 2/7 Select heterozygous SNP variants for Whatshap phasing and haplotagging")
         run_command(
-            f"gzip -fdc {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
+            f"pigz -fdc -p 2 {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
             f"--phase --output_fn {q(phase_vcf_path)} --var_pct_phasing {q(args.var_pct_phasing)}",
             log_path=log_path / "2_select_hetero_snp.log",
         )
@@ -419,7 +419,7 @@ def main():
     print("")
     print("[INFO] 5/7 Select candidates for full-alignment calling")
     run_command(
-        f"gzip -fdc {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
+        f"pigz -fdc -p 2 {q(output_folder / 'pileup.vcf.gz')} | {q(args.pypy)} {q(clair3)} SelectQual "
         f"--output_fn {q(candidate_bed_path)} --var_pct_full {q(args.var_pct_full)} "
         f"--ref_pct_full {q(args.ref_pct_full)} --platform {q(args.platform)} --vcf_fn {q(args.vcf_fn)}",
         log_path=log_path / "5_select_candidate.log",

--- a/shared/interval_tree.py
+++ b/shared/interval_tree.py
@@ -18,7 +18,7 @@ def bed_tree_from(bed_file_path, expand_region=None, contig_name=None, bed_ctg_s
         return tree
 
     bed_start, bed_end = float('inf'), 0
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (bed_file_path)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (bed_file_path)))
     for row_id, row in enumerate(unzip_process.stdout):
         if row[0] == '#':
             continue

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -188,7 +188,7 @@ def reference_sequence_from(samtools_execute_command, fasta_file_path, regions):
 def vcf_candidates_from(vcf_fn, contig_name=None):
 
     known_variants_set =  set()
-    unzip_process = subprocess_popen(shlex.split("gzip -fdc %s" % (vcf_fn)))
+    unzip_process = subprocess_popen(shlex.split("pigz -fdc -p 2 %s" % (vcf_fn)))
 
     start_pos, end_pos = float('inf'), 0
     for row in unzip_process.stdout:


### PR DESCRIPTION
gzip is not an explicit dependency （issue #455）;   Replace all subprocess shell-out calls to `gzip` with `pigz`.
  `pigz` is already an explicit dependency and is a drop-in, faster replacement for `gzip`.
